### PR TITLE
Fix lenguage toggle button in small screen devices Relocated toggle button below the logo icon when screen is smaller than 420px

### DIFF
--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -311,11 +311,24 @@ body{
   text-align: left;
 }
 
-.register-toprow{
-  display:flex;
-  align-items:flex-start;
-  justify-content:space-between;
-  margin-bottom:10px;
+.register-toprow {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 420px) {
+  .register-toprow {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .logo {
+    height: 140px;
+  }
 }
 
 .logo{


### PR DESCRIPTION
Fix language toggle layout on mobile for Login and Registration pages. Added flex-wrap and gap to .register-toprow and a @media (max-width: 420px) breakpoint to stack the logo and toggle vertically on small screens.