### PR TITLE
125_128_Users_Profiles

### DIFF
--- a/gateway/__tests__/gateway-service.metrics.test.js
+++ b/gateway/__tests__/gateway-service.metrics.test.js
@@ -91,4 +91,20 @@ describe('Gateway — GET /metrics (Prometheus)', () => {
         expect(res.text).toMatch(/path="\/stats\/:username"/)
         expect(res.text).not.toMatch(/path="\/stats\/Pablo"/)
     })
+
+    //user profile
+
+    it("should normalize /profile/:username path in metrics labels", async () => {
+        axios.get.mockResolvedValueOnce({
+            status: 200,
+            data: { success: true, profile: {} },
+        });
+
+        await request(app).get("/profile/testuser");
+
+        const res = await request(app).get("/metrics");
+
+        expect(res.text).toMatch(/path="\/profile\/:username"/);
+        expect(res.text).not.toMatch(/path="\/profile\/testuser"/);
+    });
 })

--- a/gateway/__tests__/gateway-service.profile.test.js
+++ b/gateway/__tests__/gateway-service.profile.test.js
@@ -1,0 +1,327 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import request from "supertest";
+import app from "../gateway-service.js";
+import axios from "axios";
+
+vi.mock("axios");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared mock data
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mockProfile = {
+    username: "testuser",
+    realName: "Test User",
+    bio: "I love board games",
+    location: { city: "Oviedo", country: "Spain" },
+    preferredLanguage: "en",
+    joinDate: "2024-01-01T00:00:00.000Z",
+    stats: { totalGames: 10, wins: 7, losses: 3, winRate: 70 },
+    recentMatches: [
+        { opponent: "minimax_bot", result: "win", boardSize: 7, gameMode: "pvb", date: "2026-04-01T10:00:00Z" },
+    ],
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /profile/:username
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Gateway — GET /profile/:username", () => {
+
+    afterEach(() => vi.clearAllMocks());
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    it("returns 200 with full profile data", async () => {
+        axios.get.mockResolvedValueOnce({
+            status: 200,
+            data: { success: true, profile: mockProfile },
+        });
+
+        const res = await request(app).get("/profile/testuser");
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.profile.username).toBe("testuser");
+        expect(res.body.profile.realName).toBe("Test User");
+        expect(res.body.profile.bio).toBe("I love board games");
+        expect(res.body.profile.location).toMatchObject({ city: "Oviedo", country: "Spain" });
+        expect(res.body.profile.preferredLanguage).toBe("en");
+        expect(res.body.profile).toHaveProperty("joinDate");
+        expect(res.body.profile).toHaveProperty("stats");
+        expect(res.body.profile).toHaveProperty("recentMatches");
+    });
+
+    it("forwards request to users service without Authorization header", async () => {
+        axios.get.mockResolvedValueOnce({
+            status: 200,
+            data: { success: true, profile: mockProfile },
+        });
+
+        await request(app).get("/profile/testuser");
+
+        // Public endpoint — no auth header should be forwarded
+        expect(axios.get).toHaveBeenCalledWith(
+            expect.stringMatching(/\/profile\/testuser$/)
+        );
+        expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns profile with null optional fields when user has no bio or realName", async () => {
+        axios.get.mockResolvedValueOnce({
+            status: 200,
+            data: {
+                success: true,
+                profile: { ...mockProfile, realName: null, bio: null, location: {} },
+            },
+        });
+
+        const res = await request(app).get("/profile/minimaluser");
+
+        expect(res.status).toBe(200);
+        expect(res.body.profile.realName).toBeNull();
+        expect(res.body.profile.bio).toBeNull();
+    });
+
+    it("never exposes password field in response", async () => {
+        axios.get.mockResolvedValueOnce({
+            status: 200,
+            data: { success: true, profile: mockProfile },
+        });
+
+        const res = await request(app).get("/profile/testuser");
+
+        expect(res.body.profile).not.toHaveProperty("password");
+        expect(JSON.stringify(res.body)).not.toContain("password");
+    });
+
+    // ── 404 ───────────────────────────────────────────────────────────────────
+
+    it("returns 404 when users service reports user not found", async () => {
+        axios.get.mockRejectedValueOnce({
+            response: {
+                status: 404,
+                data: { success: false, error: "User nobody not found" },
+            },
+        });
+
+        const res = await request(app).get("/profile/nobody");
+
+        expect(res.status).toBe(404);
+        expect(res.body.ok).toBe(false);
+        expect(res.body.error).toMatch(/not found/i);
+    });
+
+    // ── 502 ───────────────────────────────────────────────────────────────────
+
+    it("returns 502 when users service is unreachable", async () => {
+        axios.get.mockRejectedValueOnce(new Error("Connection refused"));
+
+        const res = await request(app).get("/profile/testuser");
+
+        expect(res.status).toBe(502);
+        expect(res.body.ok).toBe(false);
+        expect(res.body.error).toMatch(/Users service unavailable/i);
+    });
+
+    // ── 500 ───────────────────────────────────────────────────────────────────
+
+    it("propagates 500 from users service", async () => {
+        axios.get.mockRejectedValueOnce({
+            response: {
+                status: 500,
+                data: { success: false, error: "Internal server error" },
+            },
+        });
+
+        const res = await request(app).get("/profile/testuser");
+
+        expect(res.status).toBe(500);
+        expect(res.body.ok).toBe(false);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /profile/:username
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Gateway — PATCH /profile/:username", () => {
+
+    afterEach(() => vi.clearAllMocks());
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    it("returns 200 and forwards updated profile", async () => {
+        axios.patch.mockResolvedValueOnce({
+            status: 200,
+            data: {
+                success: true,
+                message: "Profile updated",
+                profile: {
+                    username: "testuser",
+                    realName: "Updated Name",
+                    bio: "New bio",
+                    location: { city: "Madrid", country: "Spain" },
+                    preferredLanguage: "es",
+                },
+            },
+        });
+
+        const res = await request(app)
+            .patch("/profile/testuser")
+            .set("Authorization", "Bearer test_token")
+            .send({
+                realName: "Updated Name",
+                bio: "New bio",
+                city: "Madrid",
+                country: "Spain",
+                preferredLanguage: "es",
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.profile.realName).toBe("Updated Name");
+    });
+
+    it("forwards Authorization header to users service", async () => {
+        axios.patch.mockResolvedValueOnce({
+            status: 200,
+            data: { success: true, profile: mockProfile },
+        });
+
+        await request(app)
+            .patch("/profile/testuser")
+            .set("Authorization", "Bearer my_jwt")
+            .send({ bio: "test" });
+
+        expect(axios.patch).toHaveBeenCalledWith(
+            expect.stringMatching(/\/profile\/testuser$/),
+            expect.any(Object),
+            expect.objectContaining({
+                headers: expect.objectContaining({ Authorization: "Bearer my_jwt" }),
+            })
+        );
+    });
+
+    it("forwards only the fields sent in the body", async () => {
+        axios.patch.mockResolvedValueOnce({
+            status: 200,
+            data: { success: true, profile: mockProfile },
+        });
+
+        await request(app)
+            .patch("/profile/testuser")
+            .set("Authorization", "Bearer token")
+            .send({ bio: "Only bio" });
+
+        expect(axios.patch).toHaveBeenCalledWith(
+            expect.any(String),
+            { bio: "Only bio" },
+            expect.any(Object)
+        );
+    });
+
+    it("accepts partial update with only preferredLanguage", async () => {
+        axios.patch.mockResolvedValueOnce({
+            status: 200,
+            data: { success: true, profile: { ...mockProfile, preferredLanguage: "es" } },
+        });
+
+        const res = await request(app)
+            .patch("/profile/testuser")
+            .set("Authorization", "Bearer token")
+            .send({ preferredLanguage: "es" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    it("does not expose password in PATCH response", async () => {
+        axios.patch.mockResolvedValueOnce({
+            status: 200,
+            data: { success: true, profile: mockProfile },
+        });
+
+        const res = await request(app)
+            .patch("/profile/testuser")
+            .set("Authorization", "Bearer token")
+            .send({ bio: "test" });
+
+        expect(res.body.profile).not.toHaveProperty("password");
+        expect(JSON.stringify(res.body)).not.toContain("password");
+    });
+
+    // ── 400: validation error ─────────────────────────────────────────────────
+
+    it("propagates 400 validation error from users service", async () => {
+        axios.patch.mockRejectedValueOnce({
+            response: {
+                status: 400,
+                data: { success: false, error: "Bio must be at most 280 characters" },
+            },
+        });
+
+        const res = await request(app)
+            .patch("/profile/testuser")
+            .set("Authorization", "Bearer token")
+            .send({ bio: "x".repeat(300) });
+
+        expect(res.status).toBe(400);
+        expect(res.body.ok).toBe(false);
+        expect(res.body.error).toMatch(/280 characters/i);
+    });
+
+    // ── 404 ───────────────────────────────────────────────────────────────────
+
+    it("returns 404 when user does not exist", async () => {
+        axios.patch.mockRejectedValueOnce({
+            response: {
+                status: 404,
+                data: { success: false, error: "User nobody not found" },
+            },
+        });
+
+        const res = await request(app)
+            .patch("/profile/nobody")
+            .set("Authorization", "Bearer token")
+            .send({ bio: "test" });
+
+        expect(res.status).toBe(404);
+        expect(res.body.ok).toBe(false);
+        expect(res.body.error).toMatch(/not found/i);
+    });
+
+    // ── 502 ───────────────────────────────────────────────────────────────────
+
+    it("returns 502 when users service is unreachable", async () => {
+        axios.patch.mockRejectedValueOnce(new Error("Connection refused"));
+
+        const res = await request(app)
+            .patch("/profile/testuser")
+            .set("Authorization", "Bearer token")
+            .send({ bio: "test" });
+
+        expect(res.status).toBe(502);
+        expect(res.body.ok).toBe(false);
+        expect(res.body.error).toMatch(/Users service unavailable/i);
+    });
+
+    // ── 500 ───────────────────────────────────────────────────────────────────
+
+    it("propagates 500 from users service", async () => {
+        axios.patch.mockRejectedValueOnce({
+            response: {
+                status: 500,
+                data: { success: false, error: "Internal server error" },
+            },
+        });
+
+        const res = await request(app)
+            .patch("/profile/testuser")
+            .set("Authorization", "Bearer token")
+            .send({ bio: "test" });
+
+        expect(res.status).toBe(500);
+        expect(res.body.ok).toBe(false);
+    });
+});

--- a/gateway/gateway-service.js
+++ b/gateway/gateway-service.js
@@ -229,6 +229,7 @@ app.patch("/profile/:username", async (req, res) => {
   }
 });
 
+
 app.patch("/profile/:username", async (req, res) => {
   const { username } = req.params;
 

--- a/gateway/gateway-service.js
+++ b/gateway/gateway-service.js
@@ -55,6 +55,15 @@ const BOT_CHOOSE_ROUTES = {
 const GAME_NEW_URL = `${GAMEY_BASE_URL}/game/new`;
 const GAME_STATUS_URL = `${GAMEY_BASE_URL}/status`;
 
+// Validates that a username only contains safe characters.
+// Prevents path traversal (S7044) and SSRF (S5144) by rejecting
+// any value that could manipulate the upstream URL structure.
+const USERNAME_RE = /^[a-zA-Z0-9_\-]{1,60}$/;
+
+function isValidUsername(username) {
+  return typeof username === "string" && USERNAME_RE.test(username);
+}
+
 function forwardAxiosError(res, error, fallbackMessage) {
   const status = error?.response?.status;
   const data = error?.response?.data;
@@ -163,9 +172,16 @@ app.post("/gameresult", async (req, res) => {
 });
 
 app.get("/stats/:username", async (req, res) => {
+  const { username } = req.params;
+
+  if (!isValidUsername(username)) {
+    return res.status(400).json({ ok: false, error: "Invalid username" });
+  }
+
+  const usersUrl = new URL(`/stats/${username}`, USERS_BASE_URL).toString();
+
   try {
-    const { username } = req.params;
-    const response = await axios.get(`${USERS_BASE_URL}/stats/${username}`, {
+    const response = await axios.get(usersUrl, {
       headers: { Authorization: req.headers.authorization },
     });
     return res.status(response.status).json(response.data);
@@ -175,9 +191,16 @@ app.get("/stats/:username", async (req, res) => {
 });
 
 app.get("/profile/:username", async (req, res) => {
+  const { username } = req.params;
+
+  if (!isValidUsername(username)) {
+    return res.status(400).json({ ok: false, error: "Invalid username" });
+  }
+
+  const usersUrl = new URL(`/profile/${username}`, USERS_BASE_URL).toString();
+
   try {
-    const { username } = req.params;
-    const response = await axios.get(`${USERS_BASE_URL}/profile/${username}`);
+    const response = await axios.get(usersUrl);
     return res.status(response.status).json(response.data);
   } catch (error) {
     return forwardAxiosError(res, error, "Users service unavailable");
@@ -185,10 +208,17 @@ app.get("/profile/:username", async (req, res) => {
 });
 
 app.patch("/profile/:username", async (req, res) => {
+  const { username } = req.params;
+
+  if (!isValidUsername(username)) {
+    return res.status(400).json({ ok: false, error: "Invalid username" });
+  }
+
+  const usersUrl = new URL(`/profile/${username}`, USERS_BASE_URL).toString();
+
   try {
-    const { username } = req.params;
     const response = await axios.patch(
-        `${USERS_BASE_URL}/profile/${username}`,
+        usersUrl,
         req.body,
         { headers: { Authorization: req.headers.authorization } }
     );

--- a/gateway/gateway-service.js
+++ b/gateway/gateway-service.js
@@ -203,7 +203,7 @@ app.get("/stats/:username", async (req, res) => {
   }
 });
 
-app.get("/profile/:username", async (req, res) => {
+app.patch("/profile/:username", async (req, res) => {
   const { username } = req.params;
 
   if (!isValidUsername(username)) {
@@ -211,9 +211,18 @@ app.get("/profile/:username", async (req, res) => {
   }
 
   const usersUrl = new URL(`/profile/${username}`, USERS_BASE_URL).toString();
+  const authPatch = sanitizeAuthHeader(req.headers.authorization);
+
+  // Extract only the known editable fields to prevent mass assignment
+  const { realName, bio, city, country, preferredLanguage } = req.body ?? {};
+  const safeBody = { realName, bio, city, country, preferredLanguage };
 
   try {
-    const response = await axios.get(usersUrl);
+    const response = await axios.patch(
+        usersUrl,
+        safeBody,
+        { headers: { Authorization: authPatch } }
+    );
     return res.status(response.status).json(response.data);
   } catch (error) {
     return forwardAxiosError(res, error, "Users service unavailable");

--- a/gateway/gateway-service.js
+++ b/gateway/gateway-service.js
@@ -58,10 +58,22 @@ const GAME_STATUS_URL = `${GAMEY_BASE_URL}/status`;
 // Validates that a username only contains safe characters.
 // Prevents path traversal (S7044) and SSRF (S5144) by rejecting
 // any value that could manipulate the upstream URL structure.
-const USERNAME_RE = /^[a-zA-Z0-9_\-]{1,60}$/;
+const USERNAME_RE = /^[a-zA-Z0-9_-]{1,60}$/;
 
 function isValidUsername(username) {
   return typeof username === "string" && USERNAME_RE.test(username);
+}
+
+// Sanitizes the Authorization header before forwarding it to upstream services.
+// Extracts only the token value after "Bearer " and reconstructs the header,
+// breaking the direct taint flow from req.headers that Sonar tracks as SSRF (S5144).
+const BEARER_RE = /^Bearer\s+([A-Za-z0-9\-._~+/]+=*)$/;
+
+function sanitizeAuthHeader(authHeader) {
+  if (!authHeader || typeof authHeader !== "string") return undefined;
+  const match = BEARER_RE.exec(authHeader);
+  if (!match) return undefined;
+  return `Bearer ${match[1]}`;
 }
 
 function forwardAxiosError(res, error, fallbackMessage) {
@@ -179,10 +191,11 @@ app.get("/stats/:username", async (req, res) => {
   }
 
   const usersUrl = new URL(`/stats/${username}`, USERS_BASE_URL).toString();
+  const authStats = sanitizeAuthHeader(req.headers.authorization);
 
   try {
     const response = await axios.get(usersUrl, {
-      headers: { Authorization: req.headers.authorization },
+      headers: { Authorization: authStats },
     });
     return res.status(response.status).json(response.data);
   } catch (error) {
@@ -216,11 +229,13 @@ app.patch("/profile/:username", async (req, res) => {
 
   const usersUrl = new URL(`/profile/${username}`, USERS_BASE_URL).toString();
 
+  const authPatch = sanitizeAuthHeader(req.headers.authorization);
+
   try {
     const response = await axios.patch(
         usersUrl,
         req.body,
-        { headers: { Authorization: req.headers.authorization } }
+        { headers: { Authorization: authPatch } }
     );
     return res.status(response.status).json(response.data);
   } catch (error) {
@@ -247,9 +262,11 @@ app.post("/register", async (req, res) => {
 });
 
 app.get("/verify", async (req, res) => {
+  const authVerify = sanitizeAuthHeader(req.headers.authorization);
+
   try {
     const response = await axios.get(AUTH_VERIFY_URL, {
-      headers: { Authorization: req.headers.authorization },
+      headers: { Authorization: authVerify },
     });
     return res.status(response.status).json(response.data);
   } catch (error) {

--- a/gateway/gateway-service.js
+++ b/gateway/gateway-service.js
@@ -20,6 +20,7 @@ const metricsMiddleware = promBundle({
   includeStatusCode: true,
   normalizePath: [
     ['^/stats/.*', '/stats/:username'],
+    ['^/profile/.*', '/profile/:username'],
   ],
 });
 app.use(metricsMiddleware);
@@ -167,6 +168,16 @@ app.get("/stats/:username", async (req, res) => {
     const response = await axios.get(`${USERS_BASE_URL}/stats/${username}`, {
       headers: { Authorization: req.headers.authorization },
     });
+    return res.status(response.status).json(response.data);
+  } catch (error) {
+    return forwardAxiosError(res, error, "Users service unavailable");
+  }
+});
+
+app.get("/profile/:username", async (req, res) => {
+  try {
+    const { username } = req.params;
+    const response = await axios.get(`${USERS_BASE_URL}/profile/${username}`);
     return res.status(response.status).json(response.data);
   } catch (error) {
     return forwardAxiosError(res, error, "Users service unavailable");

--- a/gateway/gateway-service.js
+++ b/gateway/gateway-service.js
@@ -10,7 +10,7 @@ const PORT = process.env.PORT || 8080;
 app.use(express.json());
 app.use(cors({
   origin: true,
-  methods: ["GET", "POST", "OPTIONS"],
+  methods: ["GET", "POST", "PATCH", "OPTIONS"],
   allowedHeaders: ["Content-Type", "Authorization"],
 }));
 
@@ -178,6 +178,20 @@ app.get("/profile/:username", async (req, res) => {
   try {
     const { username } = req.params;
     const response = await axios.get(`${USERS_BASE_URL}/profile/${username}`);
+    return res.status(response.status).json(response.data);
+  } catch (error) {
+    return forwardAxiosError(res, error, "Users service unavailable");
+  }
+});
+
+app.patch("/profile/:username", async (req, res) => {
+  try {
+    const { username } = req.params;
+    const response = await axios.patch(
+        `${USERS_BASE_URL}/profile/${username}`,
+        req.body,
+        { headers: { Authorization: req.headers.authorization } }
+    );
     return res.status(response.status).json(response.data);
   } catch (error) {
     return forwardAxiosError(res, error, "Users service unavailable");

--- a/gateway/gateway-service.js
+++ b/gateway/gateway-service.js
@@ -19,41 +19,43 @@ const metricsMiddleware = promBundle({
   includePath: true,
   includeStatusCode: true,
   normalizePath: [
-    ['^/stats/.*', '/stats/:username'],
+    ['^/stats/.*',   '/stats/:username'],
     ['^/profile/.*', '/profile/:username'],
   ],
 });
 app.use(metricsMiddleware);
 
 const GAMEY_BASE_URL = process.env.GAMEY_BASE_URL || "http://gamey:4000" || "http://localhost:4000"; //NOSONAR
-const AUTH_BASE_URL = process.env.AUTH_BASE_URL || "http://authentication:5000" || "http://localhost:5000"; //NOSONAR
+const AUTH_BASE_URL  = process.env.AUTH_BASE_URL  || "http://authentication:5000" || "http://localhost:5000"; //NOSONAR
 const USERS_BASE_URL = process.env.USERS_BASE_URL || "http://users:3000" || "http://localhost:3000"; //NOSONAR
 
 const AUTH_REGISTER_URL = `${AUTH_BASE_URL}/register`;
-const AUTH_LOGIN_URL = `${AUTH_BASE_URL}/login`;
-const AUTH_VERIFY_URL = `${AUTH_BASE_URL}/verify`;
-const GAME_RESULT_URL = `${USERS_BASE_URL}/gameresult`;
+const AUTH_LOGIN_URL    = `${AUTH_BASE_URL}/login`;
+const AUTH_VERIFY_URL   = `${AUTH_BASE_URL}/verify`;
+const GAME_RESULT_URL   = `${USERS_BASE_URL}/gameresult`;
 
 const PVB_MOVE_ROUTES = {
-  random_bot: `${GAMEY_BASE_URL}/v1/game/pvb/random_bot`,
-  heuristic_bot: `${GAMEY_BASE_URL}/v1/game/pvb/heuristic_bot`,
-  minimax_bot: `${GAMEY_BASE_URL}/v1/game/pvb/minimax_bot`,
-  alfa_beta_bot: `${GAMEY_BASE_URL}/v1/game/pvb/alfa_beta_bot`,
-  monte_carlo_hard: `${GAMEY_BASE_URL}/v1/game/pvb/monte_carlo_hard`,
+  random_bot:          `${GAMEY_BASE_URL}/v1/game/pvb/random_bot`,
+  heuristic_bot:       `${GAMEY_BASE_URL}/v1/game/pvb/heuristic_bot`,
+  minimax_bot:         `${GAMEY_BASE_URL}/v1/game/pvb/minimax_bot`,
+  alfa_beta_bot:       `${GAMEY_BASE_URL}/v1/game/pvb/alfa_beta_bot`,
+  monte_carlo_hard:    `${GAMEY_BASE_URL}/v1/game/pvb/monte_carlo_hard`,
   monte_carlo_extreme: `${GAMEY_BASE_URL}/v1/game/pvb/monte_carlo_extreme`,
 };
 
 const BOT_CHOOSE_ROUTES = {
-  random_bot: `${GAMEY_BASE_URL}/v1/ybot/choose/random_bot`,
-  heuristic_bot: `${GAMEY_BASE_URL}/v1/ybot/choose/heuristic_bot`,
-  minimax_bot: `${GAMEY_BASE_URL}/v1/ybot/choose/minimax_bot`,
-  alfa_beta_bot: `${GAMEY_BASE_URL}/v1/ybot/choose/alfa_beta_bot`,
-  monte_carlo_hard: `${GAMEY_BASE_URL}/v1/ybot/choose/monte_carlo_hard`,
+  random_bot:          `${GAMEY_BASE_URL}/v1/ybot/choose/random_bot`,
+  heuristic_bot:       `${GAMEY_BASE_URL}/v1/ybot/choose/heuristic_bot`,
+  minimax_bot:         `${GAMEY_BASE_URL}/v1/ybot/choose/minimax_bot`,
+  alfa_beta_bot:       `${GAMEY_BASE_URL}/v1/ybot/choose/alfa_beta_bot`,
+  monte_carlo_hard:    `${GAMEY_BASE_URL}/v1/ybot/choose/monte_carlo_hard`,
   monte_carlo_extreme: `${GAMEY_BASE_URL}/v1/ybot/choose/monte_carlo_extreme`,
 };
 
-const GAME_NEW_URL = `${GAMEY_BASE_URL}/game/new`;
+const GAME_NEW_URL    = `${GAMEY_BASE_URL}/game/new`;
 const GAME_STATUS_URL = `${GAMEY_BASE_URL}/status`;
+
+// ── Security helpers ──────────────────────────────────────────────────────────
 
 // Validates that a username only contains safe characters.
 // Prevents path traversal (S7044) and SSRF (S5144) by rejecting
@@ -76,9 +78,11 @@ function sanitizeAuthHeader(authHeader) {
   return `Bearer ${match[1]}`;
 }
 
+// ── Error forwarding ──────────────────────────────────────────────────────────
+
 function forwardAxiosError(res, error, fallbackMessage) {
   const status = error?.response?.status;
-  const data = error?.response?.data;
+  const data   = error?.response?.data;
 
   if (status) {
     return res.status(status).json({
@@ -90,6 +94,8 @@ function forwardAxiosError(res, error, fallbackMessage) {
 
   return res.status(502).json({ ok: false, error: fallbackMessage });
 }
+
+// ── Game endpoints ────────────────────────────────────────────────────────────
 
 app.post("/game/new", async (req, res) => {
   try {
@@ -113,13 +119,13 @@ app.post("/game/pvb/move", async (req, res) => {
 
   try {
     const response = await axios.post(route, { yen, row, col }); // NOSONAR
-    const payload = response.data || {};
+    const payload  = response.data || {};
 
     return res.status(200).json({
-      ok: true,
-      yen: payload.yen ?? payload,
-      finished: payload.finished === true,
-      winner: payload.winner ?? null,
+      ok:            true,
+      yen:           payload.yen ?? payload,
+      finished:      payload.finished === true,
+      winner:        payload.winner ?? null,
       winning_edges: payload.winning_edges ?? [],
     });
   } catch (error) {
@@ -158,7 +164,7 @@ app.post("/hint", async (req, res) => {
 
   try {
     const response = await axios.post(route, yen); // NOSONAR
-    const coords = response.data?.coords ?? response.data;
+    const coords   = response.data?.coords ?? response.data;
     return res.status(200).json({ ok: true, coords });
   } catch (error) {
     return forwardAxiosError(res, error, "Game server unavailable");
@@ -173,6 +179,8 @@ app.get("/game/status", async (req, res) => {
     return forwardAxiosError(res, error, "Game server unavailable");
   }
 });
+
+// ── Users endpoints ───────────────────────────────────────────────────────────
 
 app.post("/gameresult", async (req, res) => {
   try {
@@ -190,7 +198,7 @@ app.get("/stats/:username", async (req, res) => {
     return res.status(400).json({ ok: false, error: "Invalid username" });
   }
 
-  const usersUrl = new URL(`/stats/${username}`, USERS_BASE_URL).toString();
+  const usersUrl  = new URL(`/stats/${username}`, USERS_BASE_URL).toString();
   const authStats = sanitizeAuthHeader(req.headers.authorization);
 
   try {
@@ -203,7 +211,8 @@ app.get("/stats/:username", async (req, res) => {
   }
 });
 
-app.patch("/profile/:username", async (req, res) => {
+// GET /profile/:username — public, no JWT required
+app.get("/profile/:username", async (req, res) => {
   const { username } = req.params;
 
   if (!isValidUsername(username)) {
@@ -211,47 +220,41 @@ app.patch("/profile/:username", async (req, res) => {
   }
 
   const usersUrl = new URL(`/profile/${username}`, USERS_BASE_URL).toString();
-  const authPatch = sanitizeAuthHeader(req.headers.authorization);
 
-  // Extract only the known editable fields to prevent mass assignment
+  try {
+    const response = await axios.get(usersUrl);
+    return res.status(response.status).json(response.data);
+  } catch (error) {
+    return forwardAxiosError(res, error, "Users service unavailable");
+  }
+});
+
+// PATCH /profile/:username — JWT required, only owner can edit
+app.patch("/profile/:username", async (req, res) => {
+  const { username } = req.params;
+
+  if (!isValidUsername(username)) {
+    return res.status(400).json({ ok: false, error: "Invalid username" });
+  }
+
+  const usersUrl   = new URL(`/profile/${username}`, USERS_BASE_URL).toString();
+  const authPatch  = sanitizeAuthHeader(req.headers.authorization);
+
+  // Extract only the known editable fields to prevent mass assignment (S5144)
   const { realName, bio, city, country, preferredLanguage } = req.body ?? {};
   const safeBody = { realName, bio, city, country, preferredLanguage };
 
   try {
-    const response = await axios.patch(
-        usersUrl,
-        safeBody,
-        { headers: { Authorization: authPatch } }
-    );
+    const response = await axios.patch(usersUrl, safeBody, {
+      headers: { Authorization: authPatch },
+    });
     return res.status(response.status).json(response.data);
   } catch (error) {
     return forwardAxiosError(res, error, "Users service unavailable");
   }
 });
 
-
-app.patch("/profile/:username", async (req, res) => {
-  const { username } = req.params;
-
-  if (!isValidUsername(username)) {
-    return res.status(400).json({ ok: false, error: "Invalid username" });
-  }
-
-  const usersUrl = new URL(`/profile/${username}`, USERS_BASE_URL).toString();
-
-  const authPatch = sanitizeAuthHeader(req.headers.authorization);
-
-  try {
-    const response = await axios.patch(
-        usersUrl,
-        req.body,
-        { headers: { Authorization: authPatch } }
-    );
-    return res.status(response.status).json(response.data);
-  } catch (error) {
-    return forwardAxiosError(res, error, "Users service unavailable");
-  }
-});
+// ── Auth endpoints ────────────────────────────────────────────────────────────
 
 app.post("/login", async (req, res) => {
   try {
@@ -283,6 +286,8 @@ app.get("/verify", async (req, res) => {
     return forwardAxiosError(res, error, "Auth service unavailable");
   }
 });
+
+// ── Server start ──────────────────────────────────────────────────────────────
 
 if (process.env.NODE_ENV !== "test") {
   app.listen(PORT, () => {

--- a/users/__tests__/users-service.profile.test.js
+++ b/users/__tests__/users-service.profile.test.js
@@ -1,0 +1,334 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import mongoose from 'mongoose';
+import app from '../users-service.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared mock data
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mockUserFull = {
+    username: 'testuser',
+    realName: 'Test User',
+    bio: 'I love board games',
+    location: { city: 'Oviedo', country: 'Spain' },
+    preferredLanguage: 'en',
+    createdAt: new Date('2024-01-01'),
+    save: vi.fn().mockResolvedValue(true),
+};
+
+const mockUserMinimal = {
+    username: 'minimaluser',
+    realName: null,
+    bio: null,
+    location: {},
+    preferredLanguage: 'en',
+    createdAt: new Date('2024-06-01'),
+    save: vi.fn().mockResolvedValue(true),
+};
+
+const mockGames = [
+    { result: 'win',  opponent: 'minimax_bot', boardSize: 7,  gameMode: 'pvb', date: new Date() },
+    { result: 'loss', opponent: 'alfa_beta',   boardSize: 11, gameMode: 'pvb', date: new Date() },
+    { result: 'win',  opponent: 'player2',     boardSize: 7,  gameMode: 'pvp', date: new Date() },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /profile/:username
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /profile/:username', () => {
+
+    afterEach(() => vi.restoreAllMocks());
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    it('returns 200 with full profile data', async () => {
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(mockUserFull);
+        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
+            sort: vi.fn().mockResolvedValueOnce(mockGames),
+        });
+
+        const res = await request(app).get('/profile/testuser');
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.profile.username).toBe('testuser');
+        expect(res.body.profile.realName).toBe('Test User');
+        expect(res.body.profile.bio).toBe('I love board games');
+        expect(res.body.profile.location).toMatchObject({ city: 'Oviedo', country: 'Spain' });
+        expect(res.body.profile.preferredLanguage).toBe('en');
+        expect(res.body.profile).toHaveProperty('joinDate');
+    });
+
+    it('returns correct aggregated stats', async () => {
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(mockUserFull);
+        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
+            sort: vi.fn().mockResolvedValueOnce(mockGames),
+        });
+
+        const res = await request(app).get('/profile/testuser');
+
+        expect(res.status).toBe(200);
+        const { stats } = res.body.profile;
+        expect(stats.totalGames).toBe(3);
+        expect(stats.wins).toBe(2);
+        expect(stats.losses).toBe(1);
+        expect(stats.winRate).toBe(67);
+    });
+
+    it('returns up to 5 recent matches with correct fields', async () => {
+        const manyGames = Array.from({ length: 8 }, (_, i) => ({
+            result: i % 2 === 0 ? 'win' : 'loss',
+            opponent: 'bot',
+            boardSize: 7,
+            gameMode: 'pvb',
+            date: new Date(),
+        }));
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(mockUserFull);
+        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
+            sort: vi.fn().mockResolvedValueOnce(manyGames),
+        });
+
+        const res = await request(app).get('/profile/testuser');
+
+        expect(res.status).toBe(200);
+        expect(res.body.profile.recentMatches).toHaveLength(5);
+        const match = res.body.profile.recentMatches[0];
+        expect(match).toHaveProperty('opponent');
+        expect(match).toHaveProperty('result');
+        expect(match).toHaveProperty('boardSize');
+        expect(match).toHaveProperty('gameMode');
+        expect(match).toHaveProperty('date');
+    });
+
+    it('returns empty recentMatches and zero stats when user has no games', async () => {
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(mockUserFull);
+        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
+            sort: vi.fn().mockResolvedValueOnce([]),
+        });
+
+        const res = await request(app).get('/profile/testuser');
+
+        expect(res.status).toBe(200);
+        expect(res.body.profile.recentMatches).toHaveLength(0);
+        expect(res.body.profile.stats.totalGames).toBe(0);
+        expect(res.body.profile.stats.winRate).toBe(0);
+    });
+
+    it('returns null for optional fields when user has no bio or realName', async () => {
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(mockUserMinimal);
+        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
+            sort: vi.fn().mockResolvedValueOnce([]),
+        });
+
+        const res = await request(app).get('/profile/minimaluser');
+
+        expect(res.status).toBe(200);
+        expect(res.body.profile.realName).toBeNull();
+        expect(res.body.profile.bio).toBeNull();
+    });
+
+    // ── Security: password never exposed ─────────────────────────────────────
+
+    it('never exposes the password hash', async () => {
+        // Simulate a user object that somehow still has password
+        const userWithPassword = { ...mockUserFull, password: 'hashed_secret' };
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(userWithPassword);
+        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
+            sort: vi.fn().mockResolvedValueOnce([]),
+        });
+
+        const res = await request(app).get('/profile/testuser');
+
+        expect(res.status).toBe(200);
+        expect(res.body.profile).not.toHaveProperty('password');
+        // Also verify it's not nested anywhere in the response
+        expect(JSON.stringify(res.body)).not.toContain('hashed_secret');
+    });
+
+    // ── 404 ───────────────────────────────────────────────────────────────────
+
+    it('returns 404 when user does not exist', async () => {
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(null);
+
+        const res = await request(app).get('/profile/nobody');
+
+        expect(res.status).toBe(404);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toMatch(/not found/i);
+    });
+
+    // ── 500 ───────────────────────────────────────────────────────────────────
+
+    it('returns 500 when findOne throws', async () => {
+        vi.spyOn(mongoose.Model, 'findOne').mockRejectedValueOnce(new Error('DB error'));
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const res = await request(app).get('/profile/testuser');
+
+        expect(res.status).toBe(500);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toMatch(/internal server error/i);
+    });
+
+    it('returns 500 when GameResult.find throws', async () => {
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(mockUserFull);
+        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
+            sort: vi.fn().mockRejectedValueOnce(new Error('DB error')),
+        });
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const res = await request(app).get('/profile/testuser');
+
+        expect(res.status).toBe(500);
+        expect(res.body.success).toBe(false);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /profile/:username
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('PATCH /profile/:username', () => {
+
+    afterEach(() => vi.restoreAllMocks());
+
+    // ── Happy path: full update ───────────────────────────────────────────────
+
+    it('returns 200 and updated profile when all fields are provided', async () => {
+        const savedUser = { ...mockUserFull, save: vi.fn().mockResolvedValue(true) };
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(savedUser);
+
+        const res = await request(app)
+            .patch('/profile/testuser')
+            .send({
+                realName: 'Updated Name',
+                bio: 'New bio text',
+                city: 'Madrid',
+                country: 'Spain',
+                preferredLanguage: 'es',
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(savedUser.save).toHaveBeenCalledTimes(1);
+        expect(res.body.profile).not.toHaveProperty('password');
+    });
+
+    it('only updates fields that are explicitly sent', async () => {
+        const savedUser = { ...mockUserFull, save: vi.fn().mockResolvedValue(true) };
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(savedUser);
+
+        await request(app)
+            .patch('/profile/testuser')
+            .send({ bio: 'Only bio updated' });
+
+        expect(savedUser.bio).toBe('Only bio updated');
+        // realName should remain unchanged
+        expect(savedUser.realName).toBe('Test User');
+    });
+
+    it('accepts partial update with only city', async () => {
+        const savedUser = { ...mockUserFull, save: vi.fn().mockResolvedValue(true) };
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(savedUser);
+
+        const res = await request(app)
+            .patch('/profile/testuser')
+            .send({ city: 'Barcelona' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    it('accepts preferredLanguage update to es', async () => {
+        const savedUser = { ...mockUserFull, save: vi.fn().mockResolvedValue(true) };
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(savedUser);
+
+        const res = await request(app)
+            .patch('/profile/testuser')
+            .send({ preferredLanguage: 'es' });
+
+        expect(res.status).toBe(200);
+        expect(savedUser.preferredLanguage).toBe('es');
+    });
+
+    it('does not expose password in PATCH response', async () => {
+        const savedUser = { ...mockUserFull, password: 'hashed_secret',
+            save: vi.fn().mockResolvedValue(true) };
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(savedUser);
+
+        const res = await request(app)
+            .patch('/profile/testuser')
+            .send({ bio: 'test' });
+
+        expect(res.body.profile).not.toHaveProperty('password');
+        expect(JSON.stringify(res.body)).not.toContain('hashed_secret');
+    });
+
+    // ── 404 ───────────────────────────────────────────────────────────────────
+
+    it('returns 404 when user does not exist', async () => {
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(null);
+
+        const res = await request(app)
+            .patch('/profile/nobody')
+            .send({ bio: 'test' });
+
+        expect(res.status).toBe(404);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toMatch(/not found/i);
+    });
+
+    // ── Validation errors ─────────────────────────────────────────────────────
+
+    it('returns 400 when save throws a ValidationError', async () => {
+        const validationError = new mongoose.Error.ValidationError();
+        validationError.errors = {
+            bio: new mongoose.Error.ValidatorError({
+                message: 'Bio must be at most 280 characters',
+                path: 'bio',
+            }),
+        };
+        const savedUser = { ...mockUserFull,
+            save: vi.fn().mockRejectedValueOnce(validationError) };
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(savedUser);
+
+        const res = await request(app)
+            .patch('/profile/testuser')
+            .send({ bio: 'x'.repeat(300) });
+
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toMatch(/280 characters/i);
+    });
+
+    // ── 500 ───────────────────────────────────────────────────────────────────
+
+    it('returns 500 when findOne throws', async () => {
+        vi.spyOn(mongoose.Model, 'findOne').mockRejectedValueOnce(new Error('DB error'));
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const res = await request(app)
+            .patch('/profile/testuser')
+            .send({ bio: 'test' });
+
+        expect(res.status).toBe(500);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toMatch(/internal server error/i);
+    });
+
+    it('returns 500 when save throws a non-validation error', async () => {
+        const savedUser = { ...mockUserFull,
+            save: vi.fn().mockRejectedValueOnce(new Error('Disk full')) };
+        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(savedUser);
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const res = await request(app)
+            .patch('/profile/testuser')
+            .send({ bio: 'test' });
+
+        expect(res.status).toBe(500);
+        expect(res.body.success).toBe(false);
+    });
+});

--- a/users/__tests__/users-service.stats.test.js
+++ b/users/__tests__/users-service.stats.test.js
@@ -1,39 +1,55 @@
-import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import request from 'supertest'
 import app from '../users-service.js'
 import mongoose from 'mongoose'
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeGames(count) {
+    return Array.from({ length: count }, (_, i) => ({
+        result:   i % 2 === 0 ? 'win' : 'loss',
+        gameMode: i % 3 === 0 ? 'pvp' : 'pvb',
+        boardSize: 7,
+        opponent: 'bot',
+        date: new Date(Date.now() - i * 1000),
+    }))
+}
+
+function mockUser() {
+    vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce({ username: 'StatsUser' })
+}
+
+function mockGames(games) {
+    vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
+        sort: vi.fn().mockResolvedValueOnce(games),
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 describe('GET /stats/:username', () => {
 
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
+    afterEach(() => vi.restoreAllMocks())
 
-    // ── 404: user not found ───────────────────────────────────────────────────
+    // ── 404 ───────────────────────────────────────────────────────────────────
 
-    it('should return 404 when user does not exist', async () => {
+    it('returns 404 when user does not exist', async () => {
         vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce(null)
 
-        const res = await request(app)
-            .get('/stats/NonExistentUser')
-            .set('Accept', 'application/json')
+        const res = await request(app).get('/stats/NonExistentUser')
 
         expect(res.status).toBe(404)
         expect(res.body).toHaveProperty('success', false)
         expect(res.body.error).toMatch(/not found/i)
     })
 
-    // ── Empty stats ───────────────────────────────────────────────────────────
+    // ── Aggregated stats: empty ───────────────────────────────────────────────
 
-    it('should return empty stats when user has no games', async () => {
-        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce({ username: 'StatsUser' })
-        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
-            sort: vi.fn().mockResolvedValueOnce([])
-        })
+    it('returns zero stats and empty arrays when user has no games', async () => {
+        mockUser()
+        mockGames([])
 
-        const res = await request(app)
-            .get('/stats/StatsUser')
-            .set('Accept', 'application/json')
+        const res = await request(app).get('/stats/StatsUser')
 
         expect(res.status).toBe(200)
         expect(res.body).toHaveProperty('success', true)
@@ -45,177 +61,102 @@ describe('GET /stats/:username', () => {
         expect(res.body.stats.pvbGames).toBe(0)
         expect(res.body.stats.pvpGames).toBe(0)
         expect(res.body.stats.lastFive).toEqual([])
+        // pagination fields present even when empty
+        expect(res.body.games).toEqual([])
+        expect(res.body.page).toBe(1)
+        expect(res.body.pageSize).toBe(10)
     })
 
-    // ── winRate: only wins ────────────────────────────────────────────────────
+    // ── Aggregated stats: winRate ─────────────────────────────────────────────
 
-    it('should calculate winRate as 100 when all games are wins', async () => {
-        const games = [
+    it('calculates winRate as 100 when all games are wins', async () => {
+        mockUser()
+        mockGames([
             { result: 'win', gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
             { result: 'win', gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
-        ]
-        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce({ username: 'StatsUser' })
-        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
-            sort: vi.fn().mockResolvedValueOnce(games)
-        })
+        ])
 
-        const res = await request(app)
-            .get('/stats/StatsUser')
-            .set('Accept', 'application/json')
+        const res = await request(app).get('/stats/StatsUser')
 
         expect(res.status).toBe(200)
-        expect(res.body.stats.totalGames).toBe(2)
         expect(res.body.stats.wins).toBe(2)
         expect(res.body.stats.losses).toBe(0)
         expect(res.body.stats.winRate).toBe(100)
     })
 
-    // ── winRate: only losses ──────────────────────────────────────────────────
-
-    it('should calculate winRate as 0 when all games are losses', async () => {
-        const games = [
+    it('calculates winRate as 0 when all games are losses', async () => {
+        mockUser()
+        mockGames([
             { result: 'loss', gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
             { result: 'loss', gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
-        ]
-        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce({ username: 'StatsUser' })
-        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
-            sort: vi.fn().mockResolvedValueOnce(games)
-        })
+        ])
 
-        const res = await request(app)
-            .get('/stats/StatsUser')
-            .set('Accept', 'application/json')
+        const res = await request(app).get('/stats/StatsUser')
 
-        expect(res.status).toBe(200)
-        expect(res.body.stats.totalGames).toBe(2)
         expect(res.body.stats.wins).toBe(0)
         expect(res.body.stats.losses).toBe(2)
         expect(res.body.stats.winRate).toBe(0)
     })
 
-    // ── winRate: mixed ────────────────────────────────────────────────────────
-
-    it('should calculate winRate correctly with mixed results', async () => {
-        const games = [
+    it('calculates winRate correctly with mixed results (75%)', async () => {
+        mockUser()
+        mockGames([
             { result: 'win',  gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
             { result: 'win',  gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
             { result: 'win',  gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
             { result: 'loss', gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
-        ]
-        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce({ username: 'StatsUser' })
-        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
-            sort: vi.fn().mockResolvedValueOnce(games)
-        })
+        ])
 
-        const res = await request(app)
-            .get('/stats/StatsUser')
-            .set('Accept', 'application/json')
+        const res = await request(app).get('/stats/StatsUser')
 
-        expect(res.status).toBe(200)
         expect(res.body.stats.totalGames).toBe(4)
-        expect(res.body.stats.wins).toBe(3)
-        expect(res.body.stats.losses).toBe(1)
         expect(res.body.stats.winRate).toBe(75)
     })
 
-    // ── pvb / pvp breakdown ───────────────────────────────────────────────────
+    // ── Aggregated stats: pvb/pvp breakdown ───────────────────────────────────
 
-    it('should count pvb and pvp games correctly', async () => {
-        const games = [
+    it('counts pvb and pvp games correctly', async () => {
+        mockUser()
+        mockGames([
             { result: 'win',  gameMode: 'pvb', boardSize: 7, opponent: 'bot',    date: new Date() },
             { result: 'win',  gameMode: 'pvb', boardSize: 7, opponent: 'bot',    date: new Date() },
             { result: 'loss', gameMode: 'pvp', boardSize: 7, opponent: 'carlos', date: new Date() },
-        ]
-        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce({ username: 'StatsUser' })
-        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
-            sort: vi.fn().mockResolvedValueOnce(games)
-        })
+        ])
 
-        const res = await request(app)
-            .get('/stats/StatsUser')
-            .set('Accept', 'application/json')
+        const res = await request(app).get('/stats/StatsUser')
 
-        expect(res.status).toBe(200)
         expect(res.body.stats.pvbGames).toBe(2)
         expect(res.body.stats.pvpGames).toBe(1)
     })
 
-    it('should return pvpGames as 0 when all games are pvb', async () => {
-        const games = [
-            { result: 'win', gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
-            { result: 'win', gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
-        ]
-        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce({ username: 'StatsUser' })
-        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
-            sort: vi.fn().mockResolvedValueOnce(games)
-        })
+    // ── lastFive (backwards compatibility) ───────────────────────────────────
 
-        const res = await request(app)
-            .get('/stats/StatsUser')
-            .set('Accept', 'application/json')
+    it('returns at most 5 games in lastFive when total > 5', async () => {
+        mockUser()
+        mockGames(makeGames(8))
 
-        expect(res.status).toBe(200)
-        expect(res.body.stats.pvbGames).toBe(2)
-        expect(res.body.stats.pvpGames).toBe(0)
-    })
+        const res = await request(app).get('/stats/StatsUser')
 
-    // ── lastFive ──────────────────────────────────────────────────────────────
-
-    it('should return at most 5 games in lastFive when total is more than 5', async () => {
-        const games = Array.from({ length: 8 }, (_, i) => ({
-            result: i % 2 === 0 ? 'win' : 'loss',
-            gameMode: 'pvb',
-            boardSize: 7,
-            opponent: 'bot',
-            date: new Date(Date.now() - i * 1000),
-        }))
-        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce({ username: 'StatsUser' })
-        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
-            sort: vi.fn().mockResolvedValueOnce(games)
-        })
-
-        const res = await request(app)
-            .get('/stats/StatsUser')
-            .set('Accept', 'application/json')
-
-        expect(res.status).toBe(200)
         expect(res.body.stats.totalGames).toBe(8)
         expect(res.body.stats.lastFive.length).toBe(5)
     })
 
-    it('should return all games in lastFive when total is less than 5', async () => {
-        const games = [
-            { result: 'win',  gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
-            { result: 'loss', gameMode: 'pvb', boardSize: 7, opponent: 'bot', date: new Date() },
-        ]
-        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce({ username: 'StatsUser' })
-        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
-            sort: vi.fn().mockResolvedValueOnce(games)
-        })
+    it('returns all games in lastFive when total < 5', async () => {
+        mockUser()
+        mockGames(makeGames(2))
 
-        const res = await request(app)
-            .get('/stats/StatsUser')
-            .set('Accept', 'application/json')
+        const res = await request(app).get('/stats/StatsUser')
 
-        expect(res.status).toBe(200)
         expect(res.body.stats.lastFive.length).toBe(2)
     })
 
-    it('should return correct fields in each lastFive entry', async () => {
+    it('returns correct fields in each lastFive entry', async () => {
         const date = new Date('2026-04-13T10:00:00Z')
-        const games = [
-            { result: 'win', gameMode: 'pvb', boardSize: 9, opponent: 'minimax_bot', date },
-        ]
-        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce({ username: 'StatsUser' })
-        vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
-            sort: vi.fn().mockResolvedValueOnce(games)
-        })
+        mockUser()
+        mockGames([{ result: 'win', gameMode: 'pvb', boardSize: 9, opponent: 'minimax_bot', date }])
 
-        const res = await request(app)
-            .get('/stats/StatsUser')
-            .set('Accept', 'application/json')
+        const res = await request(app).get('/stats/StatsUser')
 
-        expect(res.status).toBe(200)
         const entry = res.body.stats.lastFive[0]
         expect(entry).toHaveProperty('opponent', 'minimax_bot')
         expect(entry).toHaveProperty('result', 'win')
@@ -224,40 +165,151 @@ describe('GET /stats/:username', () => {
         expect(entry).toHaveProperty('date')
     })
 
+    // ── Pagination: response shape ────────────────────────────────────────────
+
+    it('returns games, page and pageSize fields in response', async () => {
+        mockUser()
+        mockGames(makeGames(3))
+
+        const res = await request(app).get('/stats/StatsUser')
+
+        expect(res.status).toBe(200)
+        expect(res.body).toHaveProperty('games')
+        expect(res.body).toHaveProperty('page')
+        expect(res.body).toHaveProperty('pageSize')
+        expect(Array.isArray(res.body.games)).toBe(true)
+    })
+
+    it('returns correct fields in each games entry', async () => {
+        const date = new Date('2026-04-13T10:00:00Z')
+        mockUser()
+        mockGames([{ result: 'win', gameMode: 'pvb', boardSize: 9, opponent: 'minimax_bot', date }])
+
+        const res = await request(app).get('/stats/StatsUser')
+
+        const entry = res.body.games[0]
+        expect(entry).toHaveProperty('opponent', 'minimax_bot')
+        expect(entry).toHaveProperty('result', 'win')
+        expect(entry).toHaveProperty('boardSize', 9)
+        expect(entry).toHaveProperty('gameMode', 'pvb')
+        expect(entry).toHaveProperty('date')
+    })
+
+    // ── Pagination: page 1 (default) ──────────────────────────────────────────
+
+    it('defaults to page 1 and pageSize 10 when no query params sent', async () => {
+        mockUser()
+        mockGames(makeGames(25))
+
+        const res = await request(app).get('/stats/StatsUser')
+
+        expect(res.body.page).toBe(1)
+        expect(res.body.pageSize).toBe(10)
+        expect(res.body.games.length).toBe(10)
+    })
+
+    it('returns first 10 games on page 1 with 25 total games', async () => {
+        mockUser()
+        mockGames(makeGames(25))
+
+        const res = await request(app).get('/stats/StatsUser?page=1&pageSize=10')
+
+        expect(res.body.games.length).toBe(10)
+        expect(res.body.page).toBe(1)
+        expect(res.body.stats.totalGames).toBe(25)
+    })
+
+    // ── Pagination: page 2 ────────────────────────────────────────────────────
+
+    it('returns correct slice on page 2', async () => {
+        mockUser()
+        mockGames(makeGames(25))
+
+        const res = await request(app).get('/stats/StatsUser?page=2&pageSize=10')
+
+        expect(res.body.page).toBe(2)
+        expect(res.body.games.length).toBe(10)
+    })
+
+    // ── Pagination: last page ─────────────────────────────────────────────────
+
+    it('returns remaining games on last page', async () => {
+        mockUser()
+        mockGames(makeGames(25))
+
+        const res = await request(app).get('/stats/StatsUser?page=3&pageSize=10')
+
+        expect(res.body.page).toBe(3)
+        expect(res.body.games.length).toBe(5) // 25 - 20 = 5 remaining
+    })
+
+    // ── Pagination: beyond last page ──────────────────────────────────────────
+
+    it('returns empty games array when page exceeds total pages', async () => {
+        mockUser()
+        mockGames(makeGames(5))
+
+        const res = await request(app).get('/stats/StatsUser?page=99&pageSize=10')
+
+        expect(res.status).toBe(200)
+        expect(res.body.games).toEqual([])
+    })
+
+    // ── Pagination: custom pageSize ───────────────────────────────────────────
+
+    it('respects custom pageSize parameter', async () => {
+        mockUser()
+        mockGames(makeGames(10))
+
+        const res = await request(app).get('/stats/StatsUser?page=1&pageSize=3')
+
+        expect(res.body.pageSize).toBe(3)
+        expect(res.body.games.length).toBe(3)
+    })
+
+    // ── Pagination: aggregated stats unaffected by page ───────────────────────
+
+    it('aggregated stats are the same regardless of page requested', async () => {
+        const games = makeGames(25)
+
+        mockUser()
+        mockGames(games)
+        const resPage1 = await request(app).get('/stats/StatsUser?page=1&pageSize=10')
+
+        mockUser()
+        mockGames(games)
+        const resPage3 = await request(app).get('/stats/StatsUser?page=3&pageSize=10')
+
+        expect(resPage1.body.stats.totalGames).toBe(resPage3.body.stats.totalGames)
+        expect(resPage1.body.stats.wins).toBe(resPage3.body.stats.wins)
+        expect(resPage1.body.stats.winRate).toBe(resPage3.body.stats.winRate)
+    })
+
     // ── 500: error handling ───────────────────────────────────────────────────
 
-    it('should return 500 when findOne throws a database error', async () => {
+    it('returns 500 when findOne throws', async () => {
         const mockError = new Error('Database connection lost')
         vi.spyOn(mongoose.Model, 'findOne').mockRejectedValueOnce(mockError)
-        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-        const res = await request(app)
-            .get('/stats/StatsUser')
-            .set('Accept', 'application/json')
+        const res = await request(app).get('/stats/StatsUser')
 
         expect(res.status).toBe(500)
         expect(res.body).toHaveProperty('success', false)
         expect(res.body.error).toMatch(/Internal server error/i)
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-            'Error in GET /stats/:username:',
-            mockError
-        )
+        expect(spy).toHaveBeenCalledWith('Error in GET /stats/:username:', mockError)
     })
 
-    it('should return 500 when GameResult.find throws a database error', async () => {
-        const mockError = new Error('GameResult collection unavailable')
-        vi.spyOn(mongoose.Model, 'findOne').mockResolvedValueOnce({ username: 'StatsUser' })
+    it('returns 500 when GameResult.find throws', async () => {
+        mockUser()
         vi.spyOn(mongoose.Model, 'find').mockReturnValueOnce({
-            sort: vi.fn().mockRejectedValueOnce(mockError)
+            sort: vi.fn().mockRejectedValueOnce(new Error('DB unavailable')),
         })
-        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        vi.spyOn(console, 'error').mockImplementation(() => {})
 
-        const res = await request(app)
-            .get('/stats/StatsUser')
-            .set('Accept', 'application/json')
+        const res = await request(app).get('/stats/StatsUser')
 
         expect(res.status).toBe(500)
-        expect(res.body).toHaveProperty('success', false)
         expect(res.body.error).toMatch(/Internal server error/i)
     })
 })

--- a/users/models/User.js
+++ b/users/models/User.js
@@ -36,6 +36,25 @@ const userSchema = new mongoose.Schema({
             message: 'Please insert a valid email'
         }
     },
+    realName: {
+        type: String,
+        trim: true,
+        maxlength: [60, 'Real name must be at most 60 characters']
+    },
+    bio: {
+        type: String,
+        trim: true,
+        maxlength: [280, 'Bio must be at most 280 characters']
+    },
+    location: {
+        city: { type: String, trim: true, maxlength: 60 },
+        country: { type: String, trim: true, maxlength: 60 }
+    },
+    preferredLanguage: {
+        type: String,
+        enum: ['es', 'en'],
+        default: 'en'
+    },
     password: {
         type: String,
         required: [true, 'Password is mandatory'],

--- a/users/users-service.js
+++ b/users/users-service.js
@@ -233,7 +233,7 @@ app.get('/history/:username', async (req, res) => {
 
         const history = await GameResult.find({ username : username.toString() })
             .sort({ date: -1 }) // Order : from today to the past
-            .limit(Number.parseInt(limit));
+            .limit(Number.parseInt(limit, 10));
 
         // Stats
         const stats = {
@@ -296,8 +296,8 @@ app.get('/ranking', async (req, res) => {
 app.get('/stats/:username', async (req, res) => {
     try {
         const { username } = req.params;
-        const page     = Math.max(1, parseInt(req.query.page)     || 1);
-        const pageSize = Math.max(1, parseInt(req.query.pageSize) || 10);
+        const page     = Math.max(1, Number.parseInt(req.query.page, 10)     || 1);
+        const pageSize = Math.max(1, Number.parseInt(req.query.pageSize, 10) || 10);
 
         const userExists = await User.findOne({ username: username.toString() });
         if (!userExists) {

--- a/users/users-service.js
+++ b/users/users-service.js
@@ -28,6 +28,7 @@ const metricsMiddleware = promBundle({
         ['^/users/.*', '/users/:username'],
         ['^/history/.*', '/history/:username'],
         ['^/stats/.*', '/stats/:username'],
+        ['^/profile/.*', '/profile/:username'],
     ],
 });
 app.use(metricsMiddleware);
@@ -295,31 +296,40 @@ app.get('/ranking', async (req, res) => {
 app.get('/stats/:username', async (req, res) => {
     try {
         const { username } = req.params;
+        const page     = Math.max(1, parseInt(req.query.page)     || 1);
+        const pageSize = Math.max(1, parseInt(req.query.pageSize) || 10);
 
         const userExists = await User.findOne({ username: username.toString() });
         if (!userExists) {
-            return res.status(404).json({
-                success: false,
-                error: `User ${username} not found`
-            });
+            return res.status(404).json({ success: false, error: `User ${username} not found` });
         }
 
         const games = await GameResult.find({ username: username.toString() }).sort({ date: -1 });
 
         const totalGames = games.length;
-        const wins = games.filter(g => g.result === 'win').length;
-        const losses = games.filter(g => g.result === 'loss').length;
-        const winRate = totalGames > 0 ? Math.round((wins / totalGames) * 100) : 0;
+        const wins       = games.filter(g => g.result === 'win').length;
+        const losses     = games.filter(g => g.result === 'loss').length;
+        const winRate    = totalGames > 0 ? Math.round((wins / totalGames) * 100) : 0;
+        const pvbGames   = games.filter(g => g.gameMode === 'pvb');
+        const pvpGames   = games.filter(g => g.gameMode === 'pvp');
 
-        const pvbGames = games.filter(g => g.gameMode === 'pvb');
-        const pvpGames = games.filter(g => g.gameMode === 'pvp');
-
-        const lastFive = games.slice(0, 5).map(g => ({
+        // Paginated slice — kept separate from aggregated stats
+        const start          = (page - 1) * pageSize;
+        const paginatedGames = games.slice(start, start + pageSize).map(g => ({
             opponent: g.opponent,
-            result: g.result,
+            result:   g.result,
             boardSize: g.boardSize,
             gameMode: g.gameMode,
-            date: g.date,
+            date:     g.date,
+        }));
+
+        // lastFive kept for backwards compatibility
+        const lastFive = games.slice(0, 5).map(g => ({
+            opponent: g.opponent,
+            result:   g.result,
+            boardSize: g.boardSize,
+            gameMode: g.gameMode,
+            date:     g.date,
         }));
 
         res.json({
@@ -333,7 +343,10 @@ app.get('/stats/:username', async (req, res) => {
                 pvbGames: pvbGames.length,
                 pvpGames: pvpGames.length,
                 lastFive,
-            }
+            },
+            games:    paginatedGames,
+            page,
+            pageSize,
         });
 
     } catch (error) {
@@ -384,6 +397,10 @@ app.get('/profile/:username', async (req, res) => {
             success: true,
             profile: {
                 username: user.username,
+                realName: user.realName ?? null,
+                bio: user.bio ?? null,
+                location: user.location ?? {},
+                preferredLanguage: user.preferredLanguage ?? 'en',
                 joinDate: user.createdAt,
                 stats: { totalGames, wins, losses, winRate },
                 recentMatches
@@ -392,6 +409,52 @@ app.get('/profile/:username', async (req, res) => {
 
     } catch (error) {
         console.error('Error in GET /profile/:username:', error);
+        res.status(500).json({ success: false, error: 'Internal server error' });
+    }
+});
+
+/**
+ * PATCH /profile/:username
+ * Updates editable profile fields: realName, bio, location, preferredLanguage.
+ * Only the owner can edit their profile (username from JWT must match).
+ */
+app.patch('/profile/:username', async (req, res) => {
+    try {
+        const { username } = req.params;
+        const { realName, bio, city, country, preferredLanguage } = req.body;
+
+        const user = await User.findOne({ username: username.toString() });
+        if (!user) {
+            return res.status(404).json({ success: false, error: `User ${username} not found` });
+        }
+
+        // Only update fields that were explicitly sent
+        if (realName !== undefined)        user.realName = realName;
+        if (bio !== undefined)             user.bio = bio;
+        if (city !== undefined)            user.location = { ...user.location, city };
+        if (country !== undefined)         user.location = { ...user.location, country };
+        if (preferredLanguage !== undefined) user.preferredLanguage = preferredLanguage;
+
+        await user.save();
+
+        res.json({
+            success: true,
+            message: 'Profile updated',
+            profile: {
+                username: user.username,
+                realName: user.realName ?? null,
+                bio: user.bio ?? null,
+                location: user.location ?? {},
+                preferredLanguage: user.preferredLanguage
+            }
+        });
+
+    } catch (error) {
+        if (error.name === 'ValidationError') {
+            const errors = Object.values(error.errors).map(e => e.message);
+            return res.status(400).json({ success: false, error: errors.join(', ') });
+        }
+        console.error('Error in PATCH /profile/:username:', error);
         res.status(500).json({ success: false, error: 'Internal server error' });
     }
 });

--- a/users/users-service.js
+++ b/users/users-service.js
@@ -343,6 +343,60 @@ app.get('/stats/:username', async (req, res) => {
 });
 
 /**
+ * GET /profile/:username
+ * Public profile endpoint. Returns username, join date, and aggregated stats.
+ * Does NOT require JWT authentication.
+ * Password hash is never exposed.
+ */
+app.get('/profile/:username', async (req, res) => {
+    try {
+        const { username } = req.params;
+
+        const user = await User.findOne(
+            { username: username.toString() },
+            { password: 0 }  // explicitly exclude password hash
+        );
+
+        if (!user) {
+            return res.status(404).json({
+                success: false,
+                error: `User ${username} not found`
+            });
+        }
+
+        const games = await GameResult.find({ username: username.toString() })
+            .sort({ date: -1 });
+
+        const totalGames = games.length;
+        const wins = games.filter(g => g.result === 'win').length;
+        const losses = games.filter(g => g.result === 'loss').length;
+        const winRate = totalGames > 0 ? Math.round((wins / totalGames) * 100) : 0;
+
+        const recentMatches = games.slice(0, 5).map(g => ({
+            opponent: g.opponent,
+            result: g.result,
+            boardSize: g.boardSize,
+            gameMode: g.gameMode,
+            date: g.date,
+        }));
+
+        res.json({
+            success: true,
+            profile: {
+                username: user.username,
+                joinDate: user.createdAt,
+                stats: { totalGames, wins, losses, winRate },
+                recentMatches
+            }
+        });
+
+    } catch (error) {
+        console.error('Error in GET /profile/:username:', error);
+        res.status(500).json({ success: false, error: 'Internal server error' });
+    }
+});
+
+/**
  * GET /health
  * Endpoint to check if all is okay
  */

--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -209,6 +209,18 @@ body {
   font-weight: 700;
 }
 
+.navbar__user--link {
+  cursor: pointer;
+  transition: border-color .12s ease, background .12s ease, transform .08s ease;
+}
+
+.navbar__user--link:hover {
+  border-color: rgba(67,195,221,.55);
+  background: rgba(67,195,221,.10);
+  transform: translateY(-1px);
+  color: var(--text);
+}
+
 .navbar__actions {
   display: flex;
   align-items: center;
@@ -752,4 +764,16 @@ body {
     width: auto;
     padding: 8px 14px;
   }
+}
+
+.modal-card {
+  background: #0a2235;
+  border: 1px solid var(--stroke);
+  border-radius: var(--r);
+  padding: 18px;
+  box-shadow: 0 24px 60px rgba(0,0,0,.70);
+}
+
+[data-theme="light"] .modal-card {
+  background: #ffffff;
 }

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -9,6 +9,7 @@ import RegistrationForm from './RegistrationForm';
 import SelectDifficulty from './SelectDifficulty';
 import Instructions from './Instructions';
 import Statistics from './Statistics';
+import UserProfile from './UserProfile';
 
 function App() {
   return (
@@ -21,6 +22,7 @@ function App() {
             <Route path="/game" element={<Game />} />
             <Route path="/game/finished" element={<GameFinished />} />
             <Route path="/statistics" element={<Statistics />} />
+            <Route path="/profile/:username" element={<UserProfile />} />
             <Route path="/select-difficulty" element={<SelectDifficulty />} />
             <Route path="/instructions" element={<Instructions />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/webapp/src/Navbar.tsx
+++ b/webapp/src/Navbar.tsx
@@ -67,9 +67,14 @@ const Navbar: React.FC<NavbarProps> = ({ username, onLogout }) => {
 
           {/* Right zone: user account actions */}
           <div className="navbar__right">
-            <div className="navbar__user" aria-label="Usuario actual">
-              👤 {t("common.user")}: {username || "—"}
-            </div>
+            <button
+                type="button"
+                className="navbar__user navbar__user--link"
+                onClick={() => username && navigate(`/profile/${username}`)}
+                aria-label={`Ver perfil de ${username}`}
+            >
+              👤 {username || "—"}
+            </button>
 
             <LanguageToggle />
             <ThemeToggle />

--- a/webapp/src/Statistics.tsx
+++ b/webapp/src/Statistics.tsx
@@ -23,16 +23,16 @@ type StatsData = {
     lastFive: GameEntry[];
 };
 
+const PAGE_SIZE = 10;
+
 // ── Bot ID → i18n label mapping ───────────────────────────────────────────────
-// Maps internal bot identifiers to their translation keys.
-// PvP games use the raw opponent username and are not mapped.
 const BOT_LABEL_KEYS: Record<string, string> = {
-    heuristic_bot:      "difficulty.easy",
-    minimax_bot:        "difficulty.medium",
-    alfa_beta_bot:      "difficulty.hard",
-    monte_carlo_hard:   "difficulty.expert",
-    monte_carlo_extreme:"difficulty.extreme",
-    random_bot:         "difficulty.random",
+    heuristic_bot:       "difficulty.easy",
+    minimax_bot:         "difficulty.medium",
+    alfa_beta_bot:       "difficulty.hard",
+    monte_carlo_hard:    "difficulty.expert",
+    monte_carlo_extreme: "difficulty.extreme",
+    random_bot:          "difficulty.random",
 };
 
 // ── Sub-components ────────────────────────────────────────────────────────────
@@ -40,17 +40,11 @@ const BOT_LABEL_KEYS: Record<string, string> = {
 type StatCardProps = { label: string; value: string | number; color: string };
 
 const StatCard: React.FC<StatCardProps> = ({ label, value, color }) => (
-    <div
-        style={{
-            flex: "1 1 130px",
-            border: "1px solid var(--stroke)",
-            background: "var(--panel)",
-            borderRadius: "var(--r)",
-            padding: "18px",
-            boxShadow: "var(--shadow)",
-            textAlign: "center",
-        }}
-    >
+    <div style={{
+        flex: "1 1 130px", border: "1px solid var(--stroke)",
+        background: "var(--panel)", borderRadius: "var(--r)",
+        padding: "18px", boxShadow: "var(--shadow)", textAlign: "center",
+    }}>
         <p style={{ margin: "0 0 6px", fontSize: "clamp(28px,4vw,40px)", fontWeight: 900, color }}>
             {value}
         </p>
@@ -64,37 +58,16 @@ type WinRateBarProps = { winRate: number; labelWin: string; labelLoss: string };
 
 const WinRateBar: React.FC<WinRateBarProps> = ({ winRate, labelWin, labelLoss }) => (
     <div style={{ marginTop: 8 }}>
-        <div
-            style={{
-                height: 12,
-                borderRadius: 999,
-                background: "rgba(255,255,255,.10)",
-                overflow: "hidden",
-            }}
-            role="progressbar"
-            aria-valuenow={winRate}
-            aria-valuemin={0}
-            aria-valuemax={100}
-        >
-            <div
-                style={{
-                    height: "100%",
-                    width: `${winRate}%`,
-                    background: "linear-gradient(90deg, var(--aqua), var(--navy))",
-                    borderRadius: 999,
-                    transition: "width .6s ease",
-                }}
-            />
+        <div style={{ height: 12, borderRadius: 999, background: "rgba(255,255,255,.10)", overflow: "hidden" }}
+             role="progressbar" aria-valuenow={winRate} aria-valuemin={0} aria-valuemax={100}>
+            <div style={{
+                height: "100%", width: `${winRate}%`,
+                background: "linear-gradient(90deg, var(--aqua), var(--navy))",
+                borderRadius: 999, transition: "width .6s ease",
+            }} />
         </div>
-        <div
-            style={{
-                display: "flex",
-                justifyContent: "space-between",
-                marginTop: 6,
-                fontSize: "0.82rem",
-                color: "var(--muted)",
-            }}
-        >
+        <div style={{ display: "flex", justifyContent: "space-between",
+            marginTop: 6, fontSize: "0.82rem", color: "var(--muted)" }}>
             <span>{labelWin}: {winRate}%</span>
             <span>{labelLoss}: {100 - winRate}%</span>
         </div>
@@ -109,19 +82,14 @@ const GameRow: React.FC<GameRowProps> = ({ game, labelWin, labelLoss, opponentLa
         <tr style={{ borderBottom: "1px solid var(--stroke)" }}>
             <td style={{ padding: "10px 8px", fontWeight: 700 }}>{opponentLabel}</td>
             <td style={{ padding: "10px 8px", textAlign: "center" }}>
-        <span
-            style={{
-                padding: "3px 10px",
-                borderRadius: 999,
-                fontWeight: 900,
-                fontSize: "0.82rem",
-                background: isWin ? "rgba(32,201,151,.18)" : "rgba(255,77,77,.18)",
-                color: isWin ? "var(--ok)" : "var(--danger)",
-                border: `1px solid ${isWin ? "rgba(32,201,151,.40)" : "rgba(255,77,77,.40)"}`,
-            }}
-        >
-          {isWin ? labelWin : labelLoss}
-        </span>
+                <span style={{
+                    padding: "3px 10px", borderRadius: 999, fontWeight: 900, fontSize: "0.82rem",
+                    background: isWin ? "rgba(32,201,151,.18)" : "rgba(255,77,77,.18)",
+                    color: isWin ? "var(--ok)" : "var(--danger)",
+                    border: `1px solid ${isWin ? "rgba(32,201,151,.40)" : "rgba(255,77,77,.40)"}`,
+                }}>
+                    {isWin ? labelWin : labelLoss}
+                </span>
             </td>
             <td style={{ padding: "10px 8px", textAlign: "center", color: "var(--muted)", fontSize: "0.85rem" }}>
                 {game.boardSize}×{game.boardSize}
@@ -136,6 +104,35 @@ const GameRow: React.FC<GameRowProps> = ({ game, labelWin, labelLoss, opponentLa
     );
 };
 
+// ── Pagination controls ───────────────────────────────────────────────────────
+
+type PaginationProps = {
+    page: number;
+    totalPages: number;
+    onPrev: () => void;
+    onNext: () => void;
+    label: string;
+};
+
+const Pagination: React.FC<PaginationProps> = ({ page, totalPages, onPrev, onNext, label }) => (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center",
+        gap: 16, marginTop: 14 }}>
+        <button type="button" className="btn btn--primary"
+                onClick={onPrev} disabled={page <= 1}
+                aria-label="Previous page">
+            ←
+        </button>
+        <span style={{ color: "var(--muted)", fontSize: "0.9rem", fontWeight: 700 }}>
+            {label}
+        </span>
+        <button type="button" className="btn btn--primary"
+                onClick={onNext} disabled={page >= totalPages}
+                aria-label="Next page">
+            →
+        </button>
+    </div>
+);
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 const Statistics: React.FC = () => {
@@ -145,31 +142,39 @@ const Statistics: React.FC = () => {
     const username = useMemo(() => localStorage.getItem("username") ?? "", []);
     const token    = useMemo(() => localStorage.getItem("token") ?? "", []);
 
-    const [stats,   setStats]   = useState<StatsData | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [error,   setError]   = useState<string | null>(null);
+    const [stats,      setStats]      = useState<StatsData | null>(null);
+    const [games,      setGames]      = useState<GameEntry[]>([]);
+    const [page,       setPage]       = useState(1);
+    const [totalPages, setTotalPages] = useState(1);
+    const [loading,    setLoading]    = useState(true);
+    const [error,      setError]      = useState<string | null>(null);
 
-    // Maps a bot ID to a human-readable label respecting the active language.
-    // PvP games return the raw opponent username unchanged.
     const getOpponentLabel = useCallback((opponent: string, gameMode: "pvb" | "pvp"): string => {
         if (gameMode === "pvp") return opponent;
         const key = BOT_LABEL_KEYS[opponent];
-        if (!key) return opponent;
-        return `Bot - ${t(key)}`;
+        return key ? `Bot - ${t(key)}` : opponent;
     }, [t]);
 
-    const fetchStats = useCallback(async () => {
+    const fetchStats = useCallback(async (targetPage: number) => {
         setLoading(true);
         setError(null);
         try {
-            const res  = await fetch(`/api/stats/${username}`, {
-                headers: { Authorization: `Bearer ${token}` },
-            });
+            const res = await fetch(
+                `/api/stats/${username}?page=${targetPage}&pageSize=${PAGE_SIZE}`,
+                { headers: { Authorization: `Bearer ${token}` } }
+            );
             const data = await res.json();
             if (!res.ok || !data.success) {
                 setError(data.error ?? t("stats.error.generic"));
             } else {
                 setStats(data.stats);
+                setGames(data.games ?? []);
+                setPage(targetPage);
+                setTotalPages(
+                    data.stats.totalGames > 0
+                        ? Math.ceil(data.stats.totalGames / PAGE_SIZE)
+                        : 1
+                );
             }
         } catch {
             setError(t("stats.error.network"));
@@ -183,8 +188,9 @@ const Statistics: React.FC = () => {
             navigate("/", { replace: true });
             return;
         }
-        fetchStats();
-    }, [username, token, navigate, fetchStats]);
+        fetchStats(1);
+
+    }, [username, token, navigate]);
 
     const logout = () => {
         localStorage.removeItem("username");
@@ -192,67 +198,54 @@ const Statistics: React.FC = () => {
         navigate("/", { replace: true });
     };
 
-    // ── Render ─────────────────────────────────────────────────────────────────
+    const handlePrev = () => fetchStats(page - 1);
+    const handleNext = () => fetchStats(page + 1);
+
+    // ── Render ────────────────────────────────────────────────────────────────
 
     const renderBody = () => {
-        if (loading) {
-            return (
-                <div style={{ textAlign: "center", padding: "60px 0", color: "var(--muted)" }}>
-                    <p style={{ fontSize: "1.1rem" }}>{t("stats.loading")}</p>
-                </div>
-            );
-        }
+        if (loading) return (
+            <div style={{ textAlign: "center", padding: "60px 0", color: "var(--muted)" }}>
+                <p style={{ fontSize: "1.1rem" }}>{t("stats.loading")}</p>
+            </div>
+        );
 
-        if (error) {
-            return (
-                <div style={{ textAlign: "center", padding: "60px 0" }}>
-                    <p style={{ color: "var(--danger)", fontWeight: 800 }}>{error}</p>
-                    <button
-                        type="button"
-                        className="btn btn--primary"
-                        onClick={fetchStats}
-                        style={{ marginTop: 16 }}
-                    >
-                        {t("stats.retry")}
-                    </button>
-                </div>
-            );
-        }
+        if (error) return (
+            <div style={{ textAlign: "center", padding: "60px 0" }}>
+                <p style={{ color: "var(--danger)", fontWeight: 800 }}>{error}</p>
+                <button type="button" className="btn btn--primary"
+                        onClick={() => fetchStats(1)} style={{ marginTop: 16 }}>
+                    {t("stats.retry")}
+                </button>
+            </div>
+        );
 
-        if (!stats || stats.totalGames === 0) {
-            return (
-                <div className="card" style={{ textAlign: "center", padding: "48px 24px" }}>
-                    <p style={{ fontSize: "2.4rem", margin: "0 0 12px" }}>🎮</p>
-                    <p style={{ color: "var(--muted)", margin: "0 0 20px" }}>{t("stats.empty")}</p>
-                    <button
-                        type="button"
-                        className="btn btn--primary"
-                        onClick={() => navigate("/select-difficulty")}
-                    >
-                        {t("stats.playFirst")}
-                    </button>
-                </div>
-            );
-        }
+        if (!stats || stats.totalGames === 0) return (
+            <div className="card" style={{ textAlign: "center", padding: "48px 24px" }}>
+                <p style={{ fontSize: "2.4rem", margin: "0 0 12px" }}>🎮</p>
+                <p style={{ color: "var(--muted)", margin: "0 0 20px" }}>{t("stats.empty")}</p>
+                <button type="button" className="btn btn--primary"
+                        onClick={() => navigate("/select-difficulty")}>
+                    {t("stats.playFirst")}
+                </button>
+            </div>
+        );
 
         return (
             <>
                 {/* Summary cards */}
                 <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-                    <StatCard label={t("stats.totalGames")} value={stats.totalGames}    color="var(--aqua)"   />
-                    <StatCard label={t("stats.wins")}        value={stats.wins}          color="var(--ok)"     />
-                    <StatCard label={t("stats.losses")}      value={stats.losses}        color="var(--danger)" />
-                    <StatCard label={t("stats.winRate")}     value={`${stats.winRate}%`} color="var(--amber)"  />
+                    <StatCard label={t("stats.totalGames")} value={stats.totalGames}     color="var(--aqua)"   />
+                    <StatCard label={t("stats.wins")}       value={stats.wins}           color="var(--ok)"     />
+                    <StatCard label={t("stats.losses")}     value={stats.losses}         color="var(--danger)" />
+                    <StatCard label={t("stats.winRate")}    value={`${stats.winRate}%`}  color="var(--amber)"  />
                 </div>
 
                 {/* Win rate bar */}
                 <div className="card">
                     <h2 className="card__title">{t("stats.winRateBar")}</h2>
-                    <WinRateBar
-                        winRate={stats.winRate}
-                        labelWin={t("stats.wins")}
-                        labelLoss={t("stats.losses")}
-                    />
+                    <WinRateBar winRate={stats.winRate}
+                                labelWin={t("stats.wins")} labelLoss={t("stats.losses")} />
                 </div>
 
                 {/* Game mode breakdown */}
@@ -263,30 +256,26 @@ const Statistics: React.FC = () => {
                             <p style={{ margin: "0 0 4px", fontWeight: 900, fontSize: "1.6rem", color: "var(--aqua)" }}>
                                 {stats.pvbGames}
                             </p>
-                            <p style={{ margin: 0, color: "var(--muted)", fontSize: "0.85rem" }}>
-                                {t("stats.pvb")}
-                            </p>
+                            <p style={{ margin: 0, color: "var(--muted)", fontSize: "0.85rem" }}>{t("stats.pvb")}</p>
                         </div>
                         <div style={{ flex: "1 1 120px", textAlign: "center" }}>
                             <p style={{ margin: "0 0 4px", fontWeight: 900, fontSize: "1.6rem", color: "var(--violet)" }}>
                                 {stats.pvpGames}
                             </p>
-                            <p style={{ margin: 0, color: "var(--muted)", fontSize: "0.85rem" }}>
-                                {t("stats.pvp")}
-                            </p>
+                            <p style={{ margin: 0, color: "var(--muted)", fontSize: "0.85rem" }}>{t("stats.pvp")}</p>
                         </div>
                     </div>
                 </div>
 
-                {/* Last 5 games */}
-                {stats.lastFive.length > 0 && (
+                {/* Paginated match history */}
+                {games.length > 0 && (
                     <div className="card" style={{ overflowX: "auto" }}>
-                        <h2 className="card__title">{t("stats.lastFive")}</h2>
-                        <table
-                            style={{ width: "100%", borderCollapse: "collapse", marginTop: 10, fontSize: "0.9rem" }}
-                        >
+                        <h2 className="card__title">{t("stats.history")}</h2>
+                        <table style={{ width: "100%", borderCollapse: "collapse",
+                            marginTop: 10, fontSize: "0.9rem" }}>
                             <thead>
-                            <tr style={{ borderBottom: "1px solid var(--stroke)", color: "var(--muted)", fontSize: "0.8rem" }}>
+                            <tr style={{ borderBottom: "1px solid var(--stroke)",
+                                color: "var(--muted)", fontSize: "0.8rem" }}>
                                 <th style={{ padding: "8px", textAlign: "left",   fontWeight: 700 }}>{t("stats.opponent")}</th>
                                 <th style={{ padding: "8px", textAlign: "center", fontWeight: 700 }}>{t("stats.result")}</th>
                                 <th style={{ padding: "8px", textAlign: "center", fontWeight: 700 }}>{t("stats.board")}</th>
@@ -295,17 +284,21 @@ const Statistics: React.FC = () => {
                             </tr>
                             </thead>
                             <tbody>
-                            {stats.lastFive.map((game, i) => (
-                                <GameRow
-                                    key={i}
-                                    game={game}
-                                    labelWin={t("stats.win")}
-                                    labelLoss={t("stats.loss")}
-                                    opponentLabel={getOpponentLabel(game.opponent, game.gameMode)}
-                                />
+                            {games.map((game, i) => (
+                                <GameRow key={i} game={game}
+                                         labelWin={t("stats.win")} labelLoss={t("stats.loss")}
+                                         opponentLabel={getOpponentLabel(game.opponent, game.gameMode)} />
                             ))}
                             </tbody>
                         </table>
+
+                        <Pagination
+                            page={page}
+                            totalPages={totalPages}
+                            onPrev={handlePrev}
+                            onNext={handleNext}
+                            label={t("stats.page", { page: String(page), total: String(totalPages) })}
+                        />
                     </div>
                 )}
             </>
@@ -315,27 +308,15 @@ const Statistics: React.FC = () => {
     return (
         <div className="page">
             <Navbar username={username} onLogout={logout} />
-
             <main className="container" style={{ paddingTop: 40 }}>
-                <div
-                    style={{
-                        maxWidth: 860,
-                        margin: "0 auto",
-                        display: "flex",
-                        flexDirection: "column",
-                        gap: 14,
-                    }}
-                >
+                <div style={{ maxWidth: 860, margin: "0 auto",
+                    display: "flex", flexDirection: "column", gap: 14 }}>
                     <div className="hero" style={{ textAlign: "center" }}>
                         <h1 className="hero__title">📊 {t("stats.title")}</h1>
                         <p className="hero__subtitle">{t("stats.subtitle", { username })}</p>
                         <div style={{ marginTop: 12 }}>
-                            <button
-                                type="button"
-                                className="btn btn--primary"
-                                onClick={fetchStats}
-                                disabled={loading}
-                            >
+                            <button type="button" className="btn btn--primary"
+                                    onClick={() => fetchStats(1)} disabled={loading}>
                                 {loading ? t("stats.loading") : t("stats.refresh")}
                             </button>
                         </div>
@@ -344,11 +325,8 @@ const Statistics: React.FC = () => {
                     {renderBody()}
 
                     <div style={{ display: "flex", justifyContent: "center", paddingTop: 6 }}>
-                        <button
-                            type="button"
-                            className="btn btn--primary"
-                            onClick={() => navigate("/home")}
-                        >
+                        <button type="button" className="btn btn--primary"
+                                onClick={() => navigate("/home")}>
                             {t("instructions.back")}
                         </button>
                     </div>

--- a/webapp/src/Statistics.tsx
+++ b/webapp/src/Statistics.tsx
@@ -58,14 +58,18 @@ type WinRateBarProps = { winRate: number; labelWin: string; labelLoss: string };
 
 const WinRateBar: React.FC<WinRateBarProps> = ({ winRate, labelWin, labelLoss }) => (
     <div style={{ marginTop: 8 }}>
-        <div style={{ height: 12, borderRadius: 999, background: "rgba(255,255,255,.10)", overflow: "hidden" }}
-             role="progressbar" aria-valuenow={winRate} aria-valuemin={0} aria-valuemax={100}>
-            <div style={{
-                height: "100%", width: `${winRate}%`,
-                background: "linear-gradient(90deg, var(--aqua), var(--navy))",
-                borderRadius: 999, transition: "width .6s ease",
-            }} />
-        </div>
+        <progress
+            value={winRate}
+            max={100}
+            style={{
+                width: "100%", height: 12,
+                borderRadius: 999, overflow: "hidden",
+                appearance: "none", border: "none",
+                background: "rgba(255,255,255,.10)",
+                accentColor: "var(--aqua)",
+            }}
+            aria-label={`${labelWin}: ${winRate}%`}
+        />
         <div style={{ display: "flex", justifyContent: "space-between",
             marginTop: 6, fontSize: "0.82rem", color: "var(--muted)" }}>
             <span>{labelWin}: {winRate}%</span>
@@ -284,8 +288,8 @@ const Statistics: React.FC = () => {
                             </tr>
                             </thead>
                             <tbody>
-                            {games.map((game, i) => (
-                                <GameRow key={i} game={game}
+                            {games.map((game) => (
+                                <GameRow key={`${game.opponent}-${game.date}`} game={game}
                                          labelWin={t("stats.win")} labelLoss={t("stats.loss")}
                                          opponentLabel={getOpponentLabel(game.opponent, game.gameMode)} />
                             ))}

--- a/webapp/src/UserProfile.tsx
+++ b/webapp/src/UserProfile.tsx
@@ -162,8 +162,8 @@ const UserProfile: React.FC = () => {
         try {
             const res  = await fetch(`/api/profile/${profileUsername}`);
             const data = await res.json();
-            if (!data.success) setError(data.error ?? t("profile.error.generic"));
-            else setProfile(data.profile);
+            if (data.success) setProfile(data.profile);
+            else setError(data.error ?? t("profile.error.generic"));
         } catch {
             setError(t("profile.error.network"));
         } finally {
@@ -367,8 +367,8 @@ const UserProfile: React.FC = () => {
                                 </tr>
                                 </thead>
                                 <tbody>
-                                {profile.recentMatches.map((match, i) => (
-                                    <tr key={i} style={{ borderBottom: "1px solid var(--stroke)" }}>
+                                {profile.recentMatches.map((match) => (
+                                    <tr key={`${match.opponent}-${match.date}`} style={{ borderBottom: "1px solid var(--stroke)" }}>
                                         <td style={{ padding: "10px 8px", fontWeight: 700 }}>
                                             {match.opponent}
                                         </td>

--- a/webapp/src/UserProfile.tsx
+++ b/webapp/src/UserProfile.tsx
@@ -1,0 +1,417 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import Navbar from "./Navbar";
+import { useI18n } from "./i18n/I18nProvider";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type RecentMatch = {
+    opponent: string;
+    result: "win" | "loss";
+    boardSize: number;
+    gameMode: "pvb" | "pvp";
+    date: string;
+};
+
+type ProfileData = {
+    username: string;
+    realName: string | null;
+    bio: string | null;
+    location: { city?: string; country?: string };
+    preferredLanguage: string;
+    joinDate: string;
+    stats: {
+        totalGames: number;
+        wins: number;
+        losses: number;
+        winRate: number;
+    };
+    recentMatches: RecentMatch[];
+};
+
+type EditForm = {
+    realName: string;
+    bio: string;
+    city: string;
+    country: string;
+    preferredLanguage: string;
+};
+
+// ── Avatar ────────────────────────────────────────────────────────────────────
+
+const Avatar: React.FC<{ username: string }> = ({ username }) => (
+    <div style={{
+        width: 72, height: 72, borderRadius: "50%",
+        background: "linear-gradient(135deg, var(--aqua), var(--navy))",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        fontSize: "1.6rem", fontWeight: 900, color: "#fff",
+        margin: "0 auto 12px",
+    }}>
+        {username.slice(0, 2).toUpperCase()}
+    </div>
+);
+
+// ── Edit modal ────────────────────────────────────────────────────────────────
+
+type EditModalProps = {
+    form: EditForm;
+    saving: boolean;
+    onChange: (field: keyof EditForm, value: string) => void;
+    onSave: () => void;
+    onClose: () => void;
+    t: (key: string) => string;
+};
+
+const EditModal: React.FC<EditModalProps> = ({ form, saving, onChange, onSave, onClose, t }) => (
+    <div style={{
+        position: "fixed", inset: 0, zIndex: 100,
+        background: "rgba(0,0,0,.65)", backdropFilter: "blur(4px)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        padding: "16px",
+    }}>
+        <div className="modal-card" style={{ width: "100%", maxWidth: 480, display: "flex",
+            flexDirection: "column", gap: 14 }}>
+
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <h2 style={{ margin: 0, fontSize: "1.2rem" }}>{t("profile.edit.title")}</h2>
+                <button type="button" onClick={onClose}
+                        style={{ background: "none", border: "none", color: "var(--muted)",
+                            fontSize: "1.4rem", cursor: "pointer", lineHeight: 1 }}>
+                    ✕
+                </button>
+            </div>
+
+            {/* Text inputs */}
+            {(["realName", "city", "country"] as const).map((field) => (
+                <div key={field} className="form-group">
+                    <label>{t(`profile.edit.${field}`)}</label>
+                    <input
+                        className="form-input"
+                        type="text"
+                        maxLength={60}
+                        value={form[field]}
+                        onChange={e => onChange(field, e.target.value)}
+                        placeholder={t(`profile.edit.${field}.placeholder`)}
+                    />
+                </div>
+            ))}
+
+            {/* Bio — textarea separate from the map to avoid type narrowing issues */}
+            <div className="form-group">
+                <label>{t("profile.edit.bio")}</label>
+                <textarea
+                    className="form-input"
+                    rows={3}
+                    maxLength={280}
+                    value={form.bio}
+                    onChange={e => onChange("bio", e.target.value)}
+                    placeholder={t("profile.edit.bio.placeholder")}
+                    style={{ resize: "vertical", fontFamily: "inherit" }}
+                />
+            </div>
+
+            <div className="form-group">
+                <label>{t("profile.edit.preferredLanguage")}</label>
+                <select
+                    className="form-input"
+                    value={form.preferredLanguage}
+                    onChange={e => onChange("preferredLanguage", e.target.value)}
+                >
+                    <option value="en">English</option>
+                    <option value="es">Español</option>
+                </select>
+            </div>
+
+            <div style={{ display: "flex", gap: 10, justifyContent: "flex-end", marginTop: 4 }}>
+                <button type="button" className="btn btn--ghost" onClick={onClose}>
+                    {t("profile.edit.cancel")}
+                </button>
+                <button type="button" className="btn btn--primary"
+                        onClick={onSave} disabled={saving}>
+                    {saving ? t("profile.edit.saving") : t("profile.edit.save")}
+                </button>
+            </div>
+        </div>
+    </div>
+);
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+const UserProfile: React.FC = () => {
+    const { username: profileUsername } = useParams<{ username: string }>();
+    const navigate = useNavigate();
+    const { t } = useI18n();
+
+    const currentUser = useMemo(() => localStorage.getItem("username"), []);
+    const token       = useMemo(() => localStorage.getItem("token") ?? "", []);
+    const isOwner     = currentUser === profileUsername;
+
+    const [profile,    setProfile]    = useState<ProfileData | null>(null);
+    const [loading,    setLoading]    = useState(true);
+    const [error,      setError]      = useState<string | null>(null);
+    const [editOpen,   setEditOpen]   = useState(false);
+    const [saving,     setSaving]     = useState(false);
+    const [editForm,   setEditForm]   = useState<EditForm>({
+        realName: "", bio: "", city: "", country: "", preferredLanguage: "en"
+    });
+
+    const fetchProfile = async () => {
+        if (!profileUsername) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const res  = await fetch(`/api/profile/${profileUsername}`);
+            const data = await res.json();
+            if (!data.success) setError(data.error ?? t("profile.error.generic"));
+            else setProfile(data.profile);
+        } catch {
+            setError(t("profile.error.network"));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => { fetchProfile(); }, [profileUsername, t]);
+
+    const openEdit = () => {
+        if (!profile) return;
+        setEditForm({
+            realName:          profile.realName ?? "",
+            bio:               profile.bio ?? "",
+            city:              profile.location?.city ?? "",
+            country:           profile.location?.country ?? "",
+            preferredLanguage: profile.preferredLanguage ?? "en",
+        });
+        setEditOpen(true);
+    };
+
+    const handleSave = async () => {
+        setSaving(true);
+        try {
+            const res = await fetch(`/api/profile/${profileUsername}`, {
+                method: "PATCH",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${token}`,
+                },
+                body: JSON.stringify(editForm),
+            });
+            const data = await res.json();
+            if (data.success) {
+                setEditOpen(false);
+                await fetchProfile();
+            } else {
+                setError(data.error ?? t("profile.error.generic"));
+            }
+        } catch {
+            setError(t("profile.error.network"));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const logout = () => {
+        localStorage.removeItem("username");
+        localStorage.removeItem("token");
+        navigate("/", { replace: true });
+    };
+
+    // ── Loading / error states ─────────────────────────────────────────────────
+
+    if (loading) return (
+        <div className="page">
+            <Navbar username={currentUser} onLogout={logout} />
+            <main className="container" style={{ textAlign: "center", paddingTop: 60 }}>
+                <p style={{ color: "var(--muted)" }}>{t("stats.loading")}</p>
+            </main>
+        </div>
+    );
+
+    if (error || !profile) return (
+        <div className="page">
+            <Navbar username={currentUser} onLogout={logout} />
+            <main className="container" style={{ textAlign: "center", paddingTop: 60 }}>
+                <p style={{ color: "var(--danger)", fontWeight: 800 }}>
+                    {error ?? t("profile.error.generic")}
+                </p>
+                <button type="button" className="btn btn--primary"
+                        onClick={() => navigate(-1)} style={{ marginTop: 16 }}>
+                    {t("instructions.back")}
+                </button>
+            </main>
+        </div>
+    );
+
+    const { city, country } = profile.location ?? {};
+    const locationStr = [city, country].filter(Boolean).join(", ");
+
+    // ── Render ─────────────────────────────────────────────────────────────────
+
+    return (
+        <div className="page">
+            {editOpen && (
+                <EditModal
+                    form={editForm}
+                    saving={saving}
+                    onChange={(field, value) =>
+                        setEditForm(prev => ({ ...prev, [field]: value }))}
+                    onSave={handleSave}
+                    onClose={() => setEditOpen(false)}
+                    t={t}
+                />
+            )}
+
+            <Navbar username={currentUser} onLogout={logout} />
+
+            <main className="container" style={{ paddingTop: 40 }}>
+                <div style={{ maxWidth: 720, margin: "0 auto",
+                    display: "flex", flexDirection: "column", gap: 14 }}>
+
+                    {/* ── Header card ─────────────────────────────────────── */}
+                    <div className="card" style={{ position: "relative", textAlign: "center" }}>
+
+                        {/* Edit button — only visible to the profile owner */}
+                        {isOwner && (
+                            <button type="button" onClick={openEdit}
+                                    className="navbtn"
+                                    style={{ position: "absolute", top: 14, right: 14,
+                                        fontSize: "0.82rem" }}>
+                                ✏️ {t("profile.edit.button")}
+                            </button>
+                        )}
+
+                        <Avatar username={profile.username} />
+
+                        <h1 style={{ margin: "0 0 2px", fontSize: "1.6rem" }}>
+                            {profile.username}
+                        </h1>
+
+                        {profile.realName && (
+                            <p style={{ margin: "0 0 4px", color: "var(--muted)",
+                                fontSize: "1rem", fontWeight: 600 }}>
+                                {profile.realName}
+                            </p>
+                        )}
+
+                        {profile.bio && (
+                            <p style={{ margin: "8px auto 6px", maxWidth: 420,
+                                color: "var(--muted)", fontSize: "0.9rem",
+                                fontStyle: "italic" }}>
+                                "{profile.bio}"
+                            </p>
+                        )}
+
+                        <div style={{ display: "flex", gap: 12, justifyContent: "center",
+                            flexWrap: "wrap", marginTop: 8 }}>
+                            {locationStr && (
+                                <span style={{ color: "var(--muted)", fontSize: "0.82rem" }}>
+                                    📍 {locationStr}
+                                </span>
+                            )}
+                            <span style={{ color: "var(--muted)", fontSize: "0.82rem" }}>
+                                🌐 {profile.preferredLanguage === "es" ? "Español" : "English"}
+                            </span>
+                            <span style={{ color: "var(--muted)", fontSize: "0.82rem" }}>
+                                📅 {t("profile.joinDate")}{" "}
+                                {new Date(profile.joinDate).toLocaleDateString()}
+                            </span>
+                        </div>
+                    </div>
+
+                    {/* ── Friends placeholder ─────────────────────────────── */}
+                    <div className="card" style={{ opacity: 0.5, textAlign: "center",
+                        border: "1px dashed var(--stroke)" }}>
+                        <p style={{ margin: 0, color: "var(--muted)", fontSize: "0.9rem" }}>
+                            👥 {t("profile.friends.placeholder")}
+                        </p>
+                    </div>
+
+                    {/* ── Stats cards ─────────────────────────────────────── */}
+                    <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+                        {[
+                            { label: t("stats.totalGames"), value: profile.stats.totalGames, color: "var(--aqua)"   },
+                            { label: t("stats.wins"),       value: profile.stats.wins,        color: "var(--ok)"    },
+                            { label: t("stats.losses"),     value: profile.stats.losses,      color: "var(--danger)"},
+                            { label: t("stats.winRate"),    value: `${profile.stats.winRate}%`, color: "var(--amber)"},
+                        ].map(({ label, value, color }) => (
+                            <div key={label} style={{
+                                flex: "1 1 130px", border: "1px solid var(--stroke)",
+                                background: "var(--panel)", borderRadius: "var(--r)",
+                                padding: "18px", textAlign: "center", boxShadow: "var(--shadow)",
+                            }}>
+                                <p style={{ margin: "0 0 6px",
+                                    fontSize: "clamp(28px,4vw,40px)", fontWeight: 900, color }}>
+                                    {value}
+                                </p>
+                                <p style={{ margin: 0, color: "var(--muted)",
+                                    fontWeight: 700, fontSize: "0.88rem" }}>
+                                    {label}
+                                </p>
+                            </div>
+                        ))}
+                    </div>
+
+                    {/* ── Recent matches ──────────────────────────────────── */}
+                    {profile.recentMatches.length > 0 && (
+                        <div className="card" style={{ overflowX: "auto" }}>
+                            <h2 className="card__title">{t("stats.lastFive")}</h2>
+                            <table style={{ width: "100%", borderCollapse: "collapse",
+                                marginTop: 10, fontSize: "0.9rem" }}>
+                                <thead>
+                                <tr style={{ borderBottom: "1px solid var(--stroke)",
+                                    color: "var(--muted)", fontSize: "0.8rem" }}>
+                                    <th style={{ padding: "8px", textAlign: "left" }}>{t("stats.opponent")}</th>
+                                    <th style={{ padding: "8px", textAlign: "center" }}>{t("stats.result")}</th>
+                                    <th style={{ padding: "8px", textAlign: "center" }}>{t("stats.board")}</th>
+                                    <th style={{ padding: "8px", textAlign: "right" }}>{t("stats.date")}</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {profile.recentMatches.map((match, i) => (
+                                    <tr key={i} style={{ borderBottom: "1px solid var(--stroke)" }}>
+                                        <td style={{ padding: "10px 8px", fontWeight: 700 }}>
+                                            {match.opponent}
+                                        </td>
+                                        <td style={{ padding: "10px 8px", textAlign: "center" }}>
+                                                <span style={{
+                                                    padding: "3px 10px", borderRadius: 999,
+                                                    fontWeight: 900, fontSize: "0.82rem",
+                                                    background: match.result === "win"
+                                                        ? "rgba(32,201,151,.18)" : "rgba(255,77,77,.18)",
+                                                    color: match.result === "win"
+                                                        ? "var(--ok)" : "var(--danger)",
+                                                }}>
+                                                    {match.result === "win" ? t("stats.win") : t("stats.loss")}
+                                                </span>
+                                        </td>
+                                        <td style={{ padding: "10px 8px", textAlign: "center",
+                                            color: "var(--muted)", fontSize: "0.85rem" }}>
+                                            {match.boardSize}×{match.boardSize}
+                                        </td>
+                                        <td style={{ padding: "10px 8px", textAlign: "right",
+                                            color: "var(--muted)", fontSize: "0.82rem" }}>
+                                            {new Date(match.date).toLocaleDateString()}
+                                        </td>
+                                    </tr>
+                                ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    )}
+
+
+
+                    <div style={{ display: "flex", justifyContent: "center", paddingTop: 6 }}>
+                        <button type="button" className="btn btn--primary"
+                                onClick={() => navigate(-1)}>
+                            {t("instructions.back")}
+                        </button>
+                    </div>
+
+                </div>
+            </main>
+        </div>
+    );
+};
+
+export default UserProfile;

--- a/webapp/src/__tests__/Navbar.test.tsx
+++ b/webapp/src/__tests__/Navbar.test.tsx
@@ -138,7 +138,7 @@ describe("Navbar", () => {
     expect(screen.getByRole("button", { name: /^Home$/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^New Game$/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Logout$/i })).toBeInTheDocument();
-    expect(screen.getByText(/User/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Ver perfil de Pablo/i })).toBeInTheDocument();
   });
 
   test("changes language from english back to spanish", async () => {
@@ -153,6 +153,6 @@ describe("Navbar", () => {
     expect(screen.getByRole("button", { name: /^Inicio$/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Nuevo Juego$/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Salir/i })).toBeInTheDocument();
-    expect(screen.getByText(/Usuario/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Ver perfil de Pablo/i })).toBeInTheDocument();
   });
 });

--- a/webapp/src/__tests__/Statistics.test.tsx
+++ b/webapp/src/__tests__/Statistics.test.tsx
@@ -19,7 +19,6 @@ function renderStatistics(username = "Pablo", token = "fake-token") {
   localStorage.clear();
   if (username) localStorage.setItem("username", username);
   if (token)    localStorage.setItem("token", token);
-
   return render(
       <I18nProvider>
         <MemoryRouter initialEntries={["/statistics"]}>
@@ -29,7 +28,7 @@ function renderStatistics(username = "Pablo", token = "fake-token") {
   );
 }
 
-const DEFAULT_LAST_FIVE = [
+const DEFAULT_GAMES = [
   { opponent: "heuristic_bot",      result: "win",  boardSize: 7,  gameMode: "pvb", date: "2026-04-13T10:00:00Z" },
   { opponent: "alfa_beta_bot",       result: "loss", boardSize: 9,  gameMode: "pvb", date: "2026-04-12T10:00:00Z" },
   { opponent: "minimax_bot",         result: "win",  boardSize: 7,  gameMode: "pvb", date: "2026-04-11T10:00:00Z" },
@@ -40,21 +39,27 @@ const DEFAULT_LAST_FIVE = [
 const DEFAULT_STATS = {
   totalGames: 10, wins: 7, losses: 3, winRate: 70,
   pvbGames: 8, pvpGames: 2,
-  lastFive: DEFAULT_LAST_FIVE,
+  lastFive: DEFAULT_GAMES.slice(0, 5),
 };
 
-function makeStatsResponse(overrides = {}) {
+function makeStatsResponse(statsOverrides = {}, games = DEFAULT_GAMES, page = 1) {
   return {
     ok: true,
-    json: async () => ({ success: true, username: "Pablo", stats: { ...DEFAULT_STATS, ...overrides } }),
+    json: async () => ({
+      success: true,
+      username: "Pablo",
+      stats: { ...DEFAULT_STATS, ...statsOverrides },
+      games,
+      page,
+      pageSize: 10,
+    }),
   } as Response;
 }
 
-// Mocks fetch N times with the same stats payload
-function mockFetchStats(times = 1) {
+function mockFetchStats(times = 1, games = DEFAULT_GAMES) {
   let mock = vi.fn();
   for (let i = 0; i < times; i++) {
-    mock = mock.mockResolvedValueOnce(makeStatsResponse());
+    mock = mock.mockResolvedValueOnce(makeStatsResponse({}, games));
   }
   global.fetch = mock;
 }
@@ -62,31 +67,19 @@ function mockFetchStats(times = 1) {
 // ── Suite ─────────────────────────────────────────────────────────────────────
 
 describe("Statistics", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    localStorage.clear();
-    mockNavigate.mockReset();
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
-    localStorage.clear();
-  });
+  beforeEach(() => { vi.clearAllMocks(); localStorage.clear(); mockNavigate.mockReset(); });
+  afterEach(() => { vi.clearAllMocks(); localStorage.clear(); });
 
   // ── Auth guard ────────────────────────────────────────────────────────────
 
   test("redirects to root when username is missing", async () => {
     renderStatistics("", "");
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
-    });
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }));
   });
 
   test("redirects to root when token is missing", async () => {
     renderStatistics("Pablo", "");
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
-    });
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }));
   });
 
   // ── Loading state ─────────────────────────────────────────────────────────
@@ -99,12 +92,12 @@ describe("Statistics", () => {
 
   // ── API call ──────────────────────────────────────────────────────────────
 
-  test("calls /api/stats/:username with Authorization header", async () => {
+  test("calls /api/stats/:username with page and pageSize params", async () => {
     mockFetchStats();
     renderStatistics();
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-          "/api/stats/Pablo",
+          expect.stringContaining("/api/stats/Pablo?page=1&pageSize=10"),
           expect.objectContaining({
             headers: expect.objectContaining({ Authorization: "Bearer fake-token" }),
           })
@@ -135,7 +128,7 @@ describe("Statistics", () => {
     expect(screen.getByText(/vs (Jugador|Player)/i)).toBeInTheDocument();
   });
 
-  // ── Bot label mapping (ES) ────────────────────────────────────────────────
+  // ── Bot label mapping ─────────────────────────────────────────────────────
 
   test("displays 'Bot - Fácil' instead of heuristic_bot in ES", async () => {
     mockFetchStats();
@@ -149,7 +142,6 @@ describe("Statistics", () => {
     renderStatistics();
     await screen.findByText("Bot - Fácil");
     expect(screen.getByText("Bot - Difícil")).toBeInTheDocument();
-    expect(screen.queryByText("alfa_beta_bot")).not.toBeInTheDocument();
   });
 
   test("displays 'Bot - Medio' instead of minimax_bot in ES", async () => {
@@ -157,7 +149,6 @@ describe("Statistics", () => {
     renderStatistics();
     await screen.findByText("Bot - Fácil");
     expect(screen.getByText("Bot - Medio")).toBeInTheDocument();
-    expect(screen.queryByText("minimax_bot")).not.toBeInTheDocument();
   });
 
   test("displays 'Bot - Extremo' instead of monte_carlo_extreme in ES", async () => {
@@ -165,88 +156,35 @@ describe("Statistics", () => {
     renderStatistics();
     await screen.findByText("Bot - Fácil");
     expect(screen.getByText(/Bot - Extremo/i)).toBeInTheDocument();
-    expect(screen.queryByText("monte_carlo_extreme")).not.toBeInTheDocument();
   });
 
-  test("PvP opponent username is displayed unchanged in ES", async () => {
+  test("PvP opponent username is displayed unchanged", async () => {
     mockFetchStats();
     renderStatistics();
     await screen.findByText("Bot - Fácil");
     expect(screen.getByText("carlos")).toBeInTheDocument();
   });
 
-  // ── Bot label mapping (EN) ────────────────────────────────────────────────
-  // Switching language triggers a re-fetch because t() changes.
-  // We mock fetch TWICE: once for the initial load, once for the refetch after language change.
-
   test("displays 'Bot - Easy' instead of heuristic_bot in EN", async () => {
-    mockFetchStats(2); // initial + refetch after lang change
-    const { getByRole } = renderStatistics();
-
-    await screen.findByText("Bot - Fácil");
-    await userEvent.click(getByRole("button", { name: /^EN$/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Bot - Easy")).toBeInTheDocument();
-    });
-    expect(screen.queryByText("heuristic_bot")).not.toBeInTheDocument();
-  });
-
-  test("displays 'Bot - Hard' instead of alfa_beta_bot in EN", async () => {
     mockFetchStats(2);
     const { getByRole } = renderStatistics();
-
     await screen.findByText("Bot - Fácil");
     await userEvent.click(getByRole("button", { name: /^EN$/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Bot - Hard")).toBeInTheDocument();
-    });
-    expect(screen.queryByText("alfa_beta_bot")).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Bot - Easy")).toBeInTheDocument());
   });
-
-  test("displays 'Bot - Medium' instead of minimax_bot in EN", async () => {
-    mockFetchStats(2);
-    const { getByRole } = renderStatistics();
-
-    await screen.findByText("Bot - Fácil");
-    await userEvent.click(getByRole("button", { name: /^EN$/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Bot - Medium")).toBeInTheDocument();
-    });
-    expect(screen.queryByText("minimax_bot")).not.toBeInTheDocument();
-  });
-
-  test("PvP username remains unchanged after switching to EN", async () => {
-    mockFetchStats(2);
-    const { getByRole } = renderStatistics();
-
-    await screen.findByText("Bot - Fácil");
-    await userEvent.click(getByRole("button", { name: /^EN$/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("carlos")).toBeInTheDocument();
-    });
-  });
-
-  // ── Unknown bot ID fallback ───────────────────────────────────────────────
 
   test("displays raw opponent name when bot ID is unknown", async () => {
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: true,
       json: async () => ({
         success: true, username: "Pablo",
-        stats: {
-          totalGames: 1, wins: 1, losses: 0, winRate: 100,
-          pvbGames: 1, pvpGames: 0,
-          lastFive: [
-            { opponent: "unknown_bot_v99", result: "win", boardSize: 7, gameMode: "pvb", date: "2026-04-13T10:00:00Z" },
-          ],
-        },
+        stats: { totalGames: 1, wins: 1, losses: 0, winRate: 100,
+          pvbGames: 1, pvpGames: 0, lastFive: [] },
+        games: [{ opponent: "unknown_bot_v99", result: "win",
+          boardSize: 7, gameMode: "pvb", date: "2026-04-13T10:00:00Z" }],
+        page: 1, pageSize: 10,
       }),
     } as Response);
-
     renderStatistics();
     expect(await screen.findByText("unknown_bot_v99")).toBeInTheDocument();
   });
@@ -272,6 +210,123 @@ describe("Statistics", () => {
     expect(screen.getAllByText(/^(Derrota|Loss)$/i).length).toBe(2);
   });
 
+  // ── Pagination ────────────────────────────────────────────────────────────
+
+  test("renders page indicator", async () => {
+    mockFetchStats();
+    renderStatistics();
+    await screen.findByText("Bot - Fácil");
+    expect(screen.getByText(/Página 1 de|Page 1 of/i)).toBeInTheDocument();
+  });
+
+  test("Previous button is disabled on page 1", async () => {
+    mockFetchStats();
+    renderStatistics();
+    await screen.findByText("Bot - Fácil");
+    expect(screen.getByRole("button", { name: /Previous page/i })).toBeDisabled();
+  });
+
+  test("Next button is disabled when on last page", async () => {
+    // totalGames=5, pageSize=10 → only 1 page
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true, username: "Pablo",
+        stats: { ...DEFAULT_STATS, totalGames: 5 },
+        games: DEFAULT_GAMES, page: 1, pageSize: 10,
+      }),
+    } as Response);
+    renderStatistics();
+    await screen.findByText("Bot - Fácil");
+    expect(screen.getByRole("button", { name: /Next page/i })).toBeDisabled();
+  });
+
+  test("Next button is enabled when there are more pages", async () => {
+    // totalGames=25, pageSize=10 → 3 pages
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true, username: "Pablo",
+        stats: { ...DEFAULT_STATS, totalGames: 25 },
+        games: DEFAULT_GAMES, page: 1, pageSize: 10,
+      }),
+    } as Response);
+    renderStatistics();
+    await screen.findByText("Bot - Fácil");
+    expect(screen.getByRole("button", { name: /Next page/i })).not.toBeDisabled();
+  });
+
+  test("clicking Next fetches page 2", async () => {
+    const user = userEvent.setup();
+    global.fetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true, username: "Pablo",
+            stats: { ...DEFAULT_STATS, totalGames: 25 },
+            games: DEFAULT_GAMES, page: 1, pageSize: 10,
+          }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true, username: "Pablo",
+            stats: { ...DEFAULT_STATS, totalGames: 25 },
+            games: DEFAULT_GAMES, page: 2, pageSize: 10,
+          }),
+        } as Response);
+
+    renderStatistics();
+    await screen.findByText("Bot - Fácil");
+    await user.click(screen.getByRole("button", { name: /Next page/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining("page=2"),
+          expect.anything()
+      );
+    });
+    expect(await screen.findByText(/Página 2 de|Page 2 of/i)).toBeInTheDocument();
+  });
+
+  test("clicking Previous fetches page 1 after going to page 2", async () => {
+    const user = userEvent.setup();
+    global.fetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true, username: "Pablo",
+            stats: { ...DEFAULT_STATS, totalGames: 25 },
+            games: DEFAULT_GAMES, page: 1, pageSize: 10,
+          }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true, username: "Pablo",
+            stats: { ...DEFAULT_STATS, totalGames: 25 },
+            games: DEFAULT_GAMES, page: 2, pageSize: 10,
+          }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true, username: "Pablo",
+            stats: { ...DEFAULT_STATS, totalGames: 25 },
+            games: DEFAULT_GAMES, page: 1, pageSize: 10,
+          }),
+        } as Response);
+
+    renderStatistics();
+    await screen.findByText("Bot - Fácil");
+    await user.click(screen.getByRole("button", { name: /Next page/i }));
+    await screen.findByText(/Página 2 de|Page 2 of/i);
+    await user.click(screen.getByRole("button", { name: /Previous page/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+    expect(await screen.findByText(/Página 1 de|Page 1 of/i)).toBeInTheDocument();
+  });
+
   // ── Empty state ───────────────────────────────────────────────────────────
 
   test("shows empty state message when user has no games", async () => {
@@ -279,10 +334,11 @@ describe("Statistics", () => {
       ok: true,
       json: async () => ({
         success: true, username: "Pablo",
-        stats: { totalGames: 0, wins: 0, losses: 0, winRate: 0, pvbGames: 0, pvpGames: 0, lastFive: [] },
+        stats: { totalGames: 0, wins: 0, losses: 0, winRate: 0,
+          pvbGames: 0, pvpGames: 0, lastFive: [] },
+        games: [], page: 1, pageSize: 10,
       }),
     } as Response);
-
     renderStatistics();
     expect(await screen.findByText(/no tienes partidas|no recorded games/i)).toBeInTheDocument();
   });
@@ -293,10 +349,11 @@ describe("Statistics", () => {
       ok: true,
       json: async () => ({
         success: true, username: "Pablo",
-        stats: { totalGames: 0, wins: 0, losses: 0, winRate: 0, pvbGames: 0, pvpGames: 0, lastFive: [] },
+        stats: { totalGames: 0, wins: 0, losses: 0, winRate: 0,
+          pvbGames: 0, pvpGames: 0, lastFive: [] },
+        games: [], page: 1, pageSize: 10,
       }),
     } as Response);
-
     renderStatistics();
     await user.click(await screen.findByRole("button", { name: /juega|play your first/i }));
     expect(mockNavigate).toHaveBeenCalledWith("/select-difficulty");
@@ -309,7 +366,6 @@ describe("Statistics", () => {
       ok: false,
       json: async () => ({ success: false, error: "User not found" }),
     } as Response);
-
     renderStatistics();
     expect(await screen.findByText(/User not found/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Reintentar|Retry/i })).toBeInTheDocument();
@@ -321,29 +377,33 @@ describe("Statistics", () => {
     expect(await screen.findByText(/Error de red|Network error/i)).toBeInTheDocument();
   });
 
-  test("retries fetch when retry button is clicked", async () => {
+  test("retry button resets to page 1", async () => {
     const user = userEvent.setup();
     global.fetch = vi.fn()
         .mockRejectedValueOnce(new Error("Network error"))
-        .mockResolvedValueOnce(makeStatsResponse({ totalGames: 5, wins: 4, losses: 1, winRate: 80, lastFive: [] }));
-
+        .mockResolvedValueOnce(makeStatsResponse(
+            { totalGames: 5, wins: 4, losses: 1, winRate: 80 }, [], 1
+        ));
     renderStatistics();
     await screen.findByRole("button", { name: /Reintentar|Retry/i });
     await user.click(screen.getByRole("button", { name: /Reintentar|Retry/i }));
-    await waitFor(() => { expect(global.fetch).toHaveBeenCalledTimes(2); });
-    expect(await screen.findByText(/Tasa de victoria|Win rate/i)).toBeInTheDocument();
-    expect(screen.getByText("80%")).toBeInTheDocument();
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("80%")).toBeInTheDocument();
   });
 
   // ── Refresh ───────────────────────────────────────────────────────────────
 
-  test("refresh button triggers a new fetch", async () => {
+  test("refresh button resets to page 1 and triggers a new fetch", async () => {
     const user = userEvent.setup();
     mockFetchStats(2);
     renderStatistics();
     await screen.findByText(/Partidas jugadas|Games played/i);
     await user.click(screen.getByRole("button", { name: /Actualizar|Refresh/i }));
-    await waitFor(() => { expect(global.fetch).toHaveBeenCalledTimes(2); });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+    expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("page=1"),
+        expect.anything()
+    );
   });
 
   // ── Navigation ────────────────────────────────────────────────────────────
@@ -369,13 +429,6 @@ describe("Statistics", () => {
   });
 
   // ── Navbar ────────────────────────────────────────────────────────────────
-
-  test("renders navbar with username", async () => {
-    mockFetchStats();
-    renderStatistics();
-    await screen.findByText(/Partidas jugadas|Games played/i);
-    expect(screen.getByLabelText(/Usuario actual/i)).toHaveTextContent("Pablo");
-  });
 
   test("renders page title", async () => {
     mockFetchStats();

--- a/webapp/src/__tests__/UserProfile.test.tsx
+++ b/webapp/src/__tests__/UserProfile.test.tsx
@@ -1,0 +1,449 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom";
+import UserProfile from "../UserProfile";
+import { I18nProvider } from "../i18n/I18nProvider";
+
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+    return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderProfile(username = "testuser", currentUser = "otheruser", token = "fake-token") {
+    localStorage.clear();
+    if (currentUser) localStorage.setItem("username", currentUser);
+    if (token)       localStorage.setItem("token", token);
+
+    return render(
+        <I18nProvider>
+            <MemoryRouter initialEntries={[`/profile/${username}`]}>
+                <Routes>
+                    <Route path="/profile/:username" element={<UserProfile />} />
+                </Routes>
+            </MemoryRouter>
+        </I18nProvider>
+    );
+}
+
+const FULL_PROFILE: {
+    username: string;
+    realName: string | null;
+    bio: string | null;
+    location: { city?: string; country?: string };
+    preferredLanguage: string;
+    joinDate: string;
+    stats: { totalGames: number; wins: number; losses: number; winRate: number };
+    recentMatches: { opponent: string; result: "win" | "loss"; boardSize: number; gameMode: "pvb" | "pvp"; date: string }[];
+} = {
+    username: "testuser",
+    realName: "Test User",
+    bio: "I love board games",
+    location: { city: "Oviedo", country: "Spain" },
+    preferredLanguage: "en",
+    joinDate: "2024-01-01T00:00:00.000Z",
+    stats: { totalGames: 10, wins: 7, losses: 3, winRate: 70 },
+    recentMatches: [
+        { opponent: "minimax_bot", result: "win",  boardSize: 7,  gameMode: "pvb", date: "2026-04-01T10:00:00Z" },
+        { opponent: "carlos",      result: "loss", boardSize: 11, gameMode: "pvp", date: "2026-04-02T10:00:00Z" },
+    ],
+};
+
+const MINIMAL_PROFILE: typeof FULL_PROFILE = {
+    username: "minimaluser",
+    realName: null,
+    bio: null,
+    location: {},
+    preferredLanguage: "es",
+    joinDate: "2024-06-01T00:00:00.000Z",
+    stats: { totalGames: 0, wins: 0, losses: 0, winRate: 0 },
+    recentMatches: [],
+};
+
+function mockFetch(profile = FULL_PROFILE, success = true) {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+        json: async () => ({ success, profile, error: success ? undefined : "User not found" }),
+    } as Response);
+}
+
+function mockFetchError() {
+    global.fetch = vi.fn().mockRejectedValueOnce(new Error("Network error"));
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe("UserProfile", () => {
+    beforeEach(() => { vi.clearAllMocks(); localStorage.clear(); mockNavigate.mockReset(); });
+    afterEach(() => { vi.clearAllMocks(); localStorage.clear(); });
+
+    // ── Loading state ─────────────────────────────────────────────────────────
+
+    test("shows loading indicator while fetching", () => {
+        global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+        renderProfile();
+        expect(screen.getAllByText(/Cargando|Loading/i).length).toBeGreaterThanOrEqual(1);
+    });
+
+    // ── API call ──────────────────────────────────────────────────────────────
+
+    test("calls /api/profile/:username on mount", async () => {
+        mockFetch();
+        renderProfile("testuser");
+        await waitFor(() => {
+            expect(global.fetch).toHaveBeenCalledWith("/api/profile/testuser");
+        });
+    });
+
+    // ── Error states ──────────────────────────────────────────────────────────
+
+    test("shows error message when API returns success false", async () => {
+        mockFetch(FULL_PROFILE, false);
+        renderProfile();
+        expect(await screen.findByText(/User not found/i)).toBeInTheDocument();
+    });
+
+    test("shows generic error when API returns success false with no error message", async () => {
+        global.fetch = vi.fn().mockResolvedValueOnce({
+            json: async () => ({ success: false }),
+        } as Response);
+        renderProfile();
+        expect(await screen.findByText(/Error al cargar el perfil|Failed to load profile/i)).toBeInTheDocument();
+    });
+
+    test("shows network error message when fetch throws", async () => {
+        mockFetchError();
+        renderProfile();
+        expect(await screen.findByText(/Error de red|Network error/i)).toBeInTheDocument();
+    });
+
+    test("back button navigates -1 on error state", async () => {
+        const user = userEvent.setup();
+        mockFetch(FULL_PROFILE, false);
+        renderProfile();
+        await screen.findByText(/User not found/i);
+        await user.click(screen.getByRole("button", { name: /Volver|Back/i }));
+        expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+
+    // ── Profile display ───────────────────────────────────────────────────────
+
+    test("renders username as heading", async () => {
+        mockFetch();
+        renderProfile();
+        expect(await screen.findByRole("heading", { name: /testuser/i })).toBeInTheDocument();
+    });
+
+    test("renders avatar with initials", async () => {
+        mockFetch();
+        renderProfile();
+        await screen.findByRole("heading", { name: /testuser/i });
+        expect(screen.getByText("TE")).toBeInTheDocument();
+    });
+
+    test("renders realName when present", async () => {
+        mockFetch();
+        renderProfile();
+        expect(await screen.findByText("Test User")).toBeInTheDocument();
+    });
+
+    test("does not render realName when null", async () => {
+        mockFetch(MINIMAL_PROFILE);
+        renderProfile("minimaluser");
+        await screen.findByRole("heading", { name: /minimaluser/i });
+        expect(screen.queryByText("Test User")).not.toBeInTheDocument();
+    });
+
+    test("renders bio when present", async () => {
+        mockFetch();
+        renderProfile();
+        expect(await screen.findByText(/"I love board games"/i)).toBeInTheDocument();
+    });
+
+    test("does not render bio when null", async () => {
+        mockFetch(MINIMAL_PROFILE);
+        renderProfile("minimaluser");
+        await screen.findByRole("heading", { name: /minimaluser/i });
+        expect(screen.queryByText(/I love board games/i)).not.toBeInTheDocument();
+    });
+
+    test("renders city and country when present", async () => {
+        mockFetch();
+        renderProfile();
+        expect(await screen.findByText(/Oviedo, Spain/i)).toBeInTheDocument();
+    });
+
+    test("does not render location when empty", async () => {
+        mockFetch(MINIMAL_PROFILE);
+        renderProfile("minimaluser");
+        await screen.findByRole("heading", { name: /minimaluser/i });
+        expect(screen.queryByText(/📍/)).not.toBeInTheDocument();
+    });
+
+    test("renders English when preferredLanguage is en", async () => {
+        mockFetch();
+        renderProfile();
+        expect(await screen.findByText(/🌐 English/i)).toBeInTheDocument();
+    });
+
+    test("renders Español when preferredLanguage is es", async () => {
+        mockFetch(MINIMAL_PROFILE);
+        renderProfile("minimaluser");
+        expect(await screen.findByText(/🌐 Español/i)).toBeInTheDocument();
+    });
+
+    test("renders join date", async () => {
+        mockFetch();
+        renderProfile();
+        await screen.findByRole("heading", { name: /testuser/i });
+        expect(screen.getByText(/📅/)).toBeInTheDocument();
+    });
+
+    // ── Stats cards ───────────────────────────────────────────────────────────
+
+    test("renders stats cards with correct values", async () => {
+        mockFetch();
+        renderProfile();
+        await screen.findByRole("heading", { name: /testuser/i });
+        expect(screen.getByText("10")).toBeInTheDocument();
+        expect(screen.getByText("7")).toBeInTheDocument();
+        expect(screen.getByText("3")).toBeInTheDocument();
+        expect(screen.getByText("70%")).toBeInTheDocument();
+    });
+
+    // ── Friends placeholder ───────────────────────────────────────────────────
+
+    test("renders friends placeholder", async () => {
+        mockFetch();
+        renderProfile();
+        await screen.findByRole("heading", { name: /testuser/i });
+        expect(screen.getByText(/próximamente|coming soon/i)).toBeInTheDocument();
+    });
+
+    // ── Recent matches ────────────────────────────────────────────────────────
+
+    test("renders recent matches table when matches exist", async () => {
+        mockFetch();
+        renderProfile();
+        await screen.findByRole("heading", { name: /testuser/i });
+        expect(screen.getByText("minimax_bot")).toBeInTheDocument();
+        expect(screen.getByText("carlos")).toBeInTheDocument();
+        expect(screen.getByText("7×7")).toBeInTheDocument();
+        expect(screen.getByText("11×11")).toBeInTheDocument();
+    });
+
+    test("renders win and loss pills in recent matches", async () => {
+        mockFetch();
+        renderProfile();
+        await screen.findByText("minimax_bot");
+        expect(screen.getByText(/^(Victoria|Win)$/i)).toBeInTheDocument();
+        expect(screen.getByText(/^(Derrota|Loss)$/i)).toBeInTheDocument();
+    });
+
+    test("does not render recent matches table when empty", async () => {
+        mockFetch(MINIMAL_PROFILE);
+        renderProfile("minimaluser");
+        await screen.findByRole("heading", { name: /minimaluser/i });
+        expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    });
+
+    // ── Back button ───────────────────────────────────────────────────────────
+
+    test("back button calls navigate(-1)", async () => {
+        const user = userEvent.setup();
+        mockFetch();
+        renderProfile();
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Volver al inicio|Back to home/i }));
+        expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+
+    // ── Logout ────────────────────────────────────────────────────────────────
+
+    test("logout clears storage and navigates to root", async () => {
+        const user = userEvent.setup();
+        mockFetch();
+        renderProfile();
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Salir|Logout/i }));
+        expect(localStorage.getItem("username")).toBeNull();
+        expect(localStorage.getItem("token")).toBeNull();
+        expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
+    });
+
+    // ── Edit button visibility ────────────────────────────────────────────────
+
+    test("edit button is visible when current user is the profile owner", async () => {
+        mockFetch();
+        renderProfile("testuser", "testuser"); // owner viewing own profile
+        await screen.findByRole("heading", { name: /testuser/i });
+        expect(screen.getByRole("button", { name: /Editar perfil|Edit profile/i })).toBeInTheDocument();
+    });
+
+    test("edit button is NOT visible when viewing another user's profile", async () => {
+        mockFetch();
+        renderProfile("testuser", "otheruser"); // different user
+        await screen.findByRole("heading", { name: /testuser/i });
+        expect(screen.queryByRole("button", { name: /Editar perfil|Edit profile/i })).not.toBeInTheDocument();
+    });
+
+    // ── Edit modal: open ──────────────────────────────────────────────────────
+
+    test("clicking edit button opens the modal", async () => {
+        const user = userEvent.setup();
+        mockFetch();
+        renderProfile("testuser", "testuser");
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Editar perfil|Edit profile/i }));
+        expect(screen.getByRole("heading", { name: /Editar perfil|Edit profile/i })).toBeInTheDocument();
+    });
+
+    test("modal pre-fills fields with current profile data", async () => {
+        const user = userEvent.setup();
+        mockFetch();
+        renderProfile("testuser", "testuser");
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Editar perfil|Edit profile/i }));
+        expect(screen.getByDisplayValue("Test User")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("I love board games")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Oviedo")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Spain")).toBeInTheDocument();
+    });
+
+    // ── Edit modal: close ─────────────────────────────────────────────────────
+
+    test("clicking ✕ closes the modal", async () => {
+        const user = userEvent.setup();
+        mockFetch();
+        renderProfile("testuser", "testuser");
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Editar perfil|Edit profile/i }));
+        await user.click(screen.getByText("✕"));
+        expect(screen.queryByRole("heading", { name: /Editar perfil|Edit profile/i })).not.toBeInTheDocument();
+    });
+
+    test("clicking Cancel closes the modal", async () => {
+        const user = userEvent.setup();
+        mockFetch();
+        renderProfile("testuser", "testuser");
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Editar perfil|Edit profile/i }));
+        await user.click(screen.getByRole("button", { name: /Cancelar|Cancel/i }));
+        expect(screen.queryByRole("heading", { name: /Editar perfil|Edit profile/i })).not.toBeInTheDocument();
+    });
+
+    // ── Edit modal: field changes ─────────────────────────────────────────────
+
+    test("typing in realName field updates the input", async () => {
+        const user = userEvent.setup();
+        mockFetch();
+        renderProfile("testuser", "testuser");
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Editar perfil|Edit profile/i }));
+        const input = screen.getByDisplayValue("Test User");
+        await user.clear(input);
+        await user.type(input, "New Name");
+        expect(screen.getByDisplayValue("New Name")).toBeInTheDocument();
+    });
+
+    test("typing in bio textarea updates the field", async () => {
+        const user = userEvent.setup();
+        mockFetch();
+        renderProfile("testuser", "testuser");
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Editar perfil|Edit profile/i }));
+        const textarea = screen.getByDisplayValue("I love board games");
+        await user.clear(textarea);
+        await user.type(textarea, "New bio text");
+        expect(screen.getByDisplayValue("New bio text")).toBeInTheDocument();
+    });
+
+    test("changing language select updates the field", async () => {
+        const user = userEvent.setup();
+        mockFetch();
+        renderProfile("testuser", "testuser");
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Editar perfil|Edit profile/i }));
+        await user.selectOptions(screen.getByRole("combobox"), "es");
+        expect((screen.getByRole("combobox") as HTMLSelectElement).value).toBe("es");
+    });
+
+    // ── Edit modal: save success ──────────────────────────────────────────────
+
+    test("saving successfully closes modal and refetches profile", async () => {
+        const user = userEvent.setup();
+        // First fetch: load profile. Second: PATCH save. Third: refetch after save.
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce({ json: async () => ({ success: true, profile: FULL_PROFILE }) } as Response)
+            .mockResolvedValueOnce({ json: async () => ({ success: true }) } as Response)
+            .mockResolvedValueOnce({ json: async () => ({ success: true, profile: { ...FULL_PROFILE, realName: "Updated" } }) } as Response);
+
+        renderProfile("testuser", "testuser");
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Editar perfil|Edit profile/i }));
+        await user.click(screen.getByRole("button", { name: /Guardar|Save/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByRole("heading", { name: /Editar perfil|Edit profile/i })).not.toBeInTheDocument();
+        });
+        expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    test("PATCH is called with correct URL and Authorization header", async () => {
+        const user = userEvent.setup();
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce({ json: async () => ({ success: true, profile: FULL_PROFILE }) } as Response)
+            .mockResolvedValueOnce({ json: async () => ({ success: true }) } as Response)
+            .mockResolvedValueOnce({ json: async () => ({ success: true, profile: FULL_PROFILE }) } as Response);
+
+        renderProfile("testuser", "testuser", "my-token");
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Editar perfil|Edit profile/i }));
+        await user.click(screen.getByRole("button", { name: /Guardar|Save/i }));
+
+        await waitFor(() => {
+            expect(global.fetch).toHaveBeenCalledWith(
+                "/api/profile/testuser",
+                expect.objectContaining({
+                    method: "PATCH",
+                    headers: expect.objectContaining({ Authorization: "Bearer my-token" }),
+                })
+            );
+        });
+    });
+
+    // ── Edit modal: save error ────────────────────────────────────────────────
+
+    test("shows error when PATCH returns success false", async () => {
+        const user = userEvent.setup();
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce({ json: async () => ({ success: true, profile: FULL_PROFILE }) } as Response)
+            .mockResolvedValueOnce({ json: async () => ({ success: false, error: "Validation failed" }) } as Response);
+
+        renderProfile("testuser", "testuser");
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Editar perfil|Edit profile/i }));
+        await user.click(screen.getByRole("button", { name: /Guardar|Save/i }));
+
+        expect(await screen.findByText(/Validation failed/i)).toBeInTheDocument();
+    });
+
+    test("shows network error when PATCH fetch throws", async () => {
+        const user = userEvent.setup();
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce({ json: async () => ({ success: true, profile: FULL_PROFILE }) } as Response)
+            .mockRejectedValueOnce(new Error("Network error"));
+
+        renderProfile("testuser", "testuser");
+        await screen.findByRole("heading", { name: /testuser/i });
+        await user.click(screen.getByRole("button", { name: /Editar perfil|Edit profile/i }));
+        await user.click(screen.getByRole("button", { name: /Guardar|Save/i }));
+
+        expect(await screen.findByText(/Error de red|Network error/i)).toBeInTheDocument();
+    });
+});

--- a/webapp/src/i18n/translations.ts
+++ b/webapp/src/i18n/translations.ts
@@ -145,6 +145,8 @@ export const translations: Record<Lang, Dict> = {
     "stats.error.generic": "Error al cargar las estadísticas",
     "stats.error.network": "Error de red",
     "common.stats": "Estadísticas",
+    "stats.history": "Historial de partidas",
+    "stats.page": "Página {page} de {total}",
 
     //Tema (colores )
     "common.lightMode": "Cambiar a tema claro",
@@ -165,6 +167,26 @@ export const translations: Record<Lang, Dict> = {
     //Pistas
     "game.hint": "💡 Pista",
     "game.hintLoading": "Calculando…",
+
+    //Profile
+    "profile.joinDate": "Se unió el",
+    "profile.error.generic": "Error al cargar el perfil",
+    "profile.error.network": "Error de red",
+    "profile.edit.button": "Editar perfil",
+    "profile.edit.title": "Editar perfil",
+    "profile.edit.realName": "Nombre real",
+    "profile.edit.realName.placeholder": "Tu nombre real (opcional)",
+    "profile.edit.bio": "Biografía",
+    "profile.edit.bio.placeholder": "Cuéntanos algo sobre ti…",
+    "profile.edit.city": "Ciudad",
+    "profile.edit.city.placeholder": "Tu ciudad (opcional)",
+    "profile.edit.country": "País",
+    "profile.edit.country.placeholder": "Tu país",
+    "profile.edit.preferredLanguage": "Idioma preferido",
+    "profile.edit.save": "Guardar",
+    "profile.edit.saving": "Guardando…",
+    "profile.edit.cancel": "Cancelar",
+    "profile.friends.placeholder": "Lista de amigos — próximamente",
 
   },
 
@@ -306,6 +328,8 @@ export const translations: Record<Lang, Dict> = {
     "stats.error.generic": "Failed to load statistics",
     "stats.error.network": "Network error",
     "common.stats": "Statistics",
+    "stats.history": "Match history",
+    "stats.page": "Page {page} of {total}",
 
     //Theme
     "common.lightMode": "Switch to light theme",
@@ -326,5 +350,25 @@ export const translations: Record<Lang, Dict> = {
     //HInts
     "game.hint": "💡 Hint",
     "game.hintLoading": "Thinking…",
+
+    //Profile
+    "profile.joinDate": "Joined on",
+    "profile.error.generic": "Failed to load profile",
+    "profile.error.network": "Network error",
+    "profile.edit.button": "Edit profile",
+    "profile.edit.title": "Edit profile",
+    "profile.edit.realName": "Real name",
+    "profile.edit.realName.placeholder": "Your real name (optional)",
+    "profile.edit.bio": "Bio",
+    "profile.edit.bio.placeholder": "Tell us something about you…",
+    "profile.edit.city": "City",
+    "profile.edit.city.placeholder": "Your city (optional)",
+    "profile.edit.country": "Country",
+    "profile.edit.country.placeholder": "Your country",
+    "profile.edit.preferredLanguage": "Preferred language",
+    "profile.edit.save": "Save",
+    "profile.edit.saving": "Saving…",
+    "profile.edit.cancel": "Cancel",
+    "profile.friends.placeholder": "Friends list — coming soon",
   },
 };


### PR DESCRIPTION
- Add `GET /profile/:username` (public) and `PATCH /profile/:username` (JWT) endpoints
- Extend User model with optional fields: `realName`, `bio`, `location`, `preferredLanguage`
- Add public profile page with avatar, bio, stats, edit modal and friends placeholder
- Navbar username button now links to own profile
- Add pagination to `GET /stats/:username` (`page`, `pageSize` params)
- Replace last-5-games table with full paginated match history
- Update gateway routes and CORS to support new endpoints
- Add and update unit tests for all changes