### PR TITLE
Fixing the release deploy file for deletion of images

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -297,5 +297,12 @@ jobs:
             echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
             echo "JWT_EXPIRES=${{ secrets.JWT_EXPIRES }}" >> .env
 
-            docker compose down || true
-            docker compose up -d --pull always
+            docker compose pull
+            docker compose up -d --remove-orphans
+
+            docker container prune -f
+            docker image prune -af
+            docker builder prune -af
+
+            docker system df
+            df -h

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -2,6 +2,12 @@ services:
   nginx:
     image: nginx:stable-alpine
     container_name: nginx
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     ports:
       - "80:80"
       - "443:443"
@@ -19,6 +25,12 @@ services:
   users:
     image: ghcr.io/arquisoft/yovi_en2c-users:latest
     container_name: users
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       - MONGODB_URI=${MONGODB_URI}
     expose:
@@ -29,6 +41,12 @@ services:
   authentication:
     image: ghcr.io/arquisoft/yovi_en2c-authentication:latest
     container_name: authentication
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       - JWT_SECRET=${JWT_SECRET}
       - JWT_EXPIRES=${JWT_EXPIRES}
@@ -44,6 +62,12 @@ services:
   webapp:
     image: ghcr.io/arquisoft/yovi_en2c-webapp:latest
     container_name: webapp
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     expose:
       - "80"
     depends_on:
@@ -54,6 +78,12 @@ services:
   multiplayer:
     image: ghcr.io/arquisoft/yovi_en2c-multiplayer:latest
     container_name: multiplayer
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       - GAMEY_BASE_URL=http://gamey:4000
       - PORT=7000
@@ -67,6 +97,12 @@ services:
   gateway:
     image: ghcr.io/arquisoft/yovi_en2c-gateway:latest
     container_name: gateway
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       - AUTH_BASE_URL=http://authentication:5000
       - GAMEY_BASE_URL=http://gamey:4000
@@ -86,6 +122,12 @@ services:
   botapi:
     image: ghcr.io/arquisoft/yovi_en2c-botapi:latest
     container_name: botapi
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       - GAMEY_BASE_URL=http://gamey:4000
       - GAMEY_API_VERSION=v1
@@ -100,6 +142,12 @@ services:
   gamey:
     image: ghcr.io/arquisoft/yovi_en2c-gamey:latest
     container_name: gamey
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     expose:
       - "4000"
     networks:
@@ -108,6 +156,12 @@ services:
   prometheus:
     image: prom/prometheus
     container_name: prometheus
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     ports:
       - "9090:9090"
     volumes:
@@ -118,6 +172,12 @@ services:
   grafana:
     image: grafana/grafana
     container_name: grafana
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     ports:
       - "9091:3000"
     volumes:


### PR DESCRIPTION
The realease deploy did not erase the docker images and the VM was getting oversaturated due to the numerous number of outdated docker images that it was storing. This should fix it